### PR TITLE
fix: stop logging private key (nsec) on startup

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -124,7 +124,6 @@ func main() {
 
 	slog.Info(fmt.Sprintf("Your public key is: %s", cfg.Nostr.PubKey))
 	slog.Info(fmt.Sprintf("Your npub is: %s", cfg.Nostr.Npub))
-	slog.Info(fmt.Sprintf("Your nsec is: %s", cfg.Nostr.Nsec))
 
 	var ctx context.Context = context.Background()
 	var nostrWrapper wrapper.Wrapper


### PR DESCRIPTION
The nsec was written to log.txt and stdout via slog, contradicting the guarantee that the private key stays local. Removed the log line; the public key and npub remain logged as they are public identifiers.

Closes #2