### PR TITLE
feat: config-driven IP allowlist and CORS origins for the API

### DIFF
--- a/config.json.dist
+++ b/config.json.dist
@@ -7,7 +7,9 @@
         "host": "localhost"
     },
     "server": {
-        "port": 8080
+        "port": 8080,
+        "allowed_ips": [],
+        "allowed_origins": []
     },
     "interval": 5,
     "nostr': {

--- a/internal/http/access.go
+++ b/internal/http/access.go
@@ -1,0 +1,57 @@
+// ABOUTME: IP allowlist middleware for the API. Loopback is always permitted;
+// ABOUTME: any other client IP must appear in the configured allowlist.
+package http
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// clientIP extracts the host portion from a RemoteAddr (host:port). A bare host
+// without a port is returned unchanged.
+func clientIP(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return remoteAddr
+	}
+	return host
+}
+
+// toIPSet turns a slice of configured IPs into a lookup set, ignoring blanks.
+func toIPSet(ips []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(ips))
+	for _, ip := range ips {
+		ip = strings.TrimSpace(ip)
+		if ip != "" {
+			set[ip] = struct{}{}
+		}
+	}
+	return set
+}
+
+// ipAllowed reports whether a client IP may access the API. Loopback is always
+// allowed (the app is local-first); any other IP must be in the allowlist. An
+// empty allowlist therefore means loopback-only.
+func ipAllowed(ip string, allowed map[string]struct{}) bool {
+	if parsed := net.ParseIP(ip); parsed != nil && parsed.IsLoopback() {
+		return true
+	}
+	_, ok := allowed[ip]
+	return ok
+}
+
+// ipAllowlist is middleware that rejects clients whose IP is neither loopback
+// nor present in the configured allowlist with a 403.
+func ipAllowlist(allowed []string) func(http.Handler) http.Handler {
+	set := toIPSet(allowed)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !ipAllowed(clientIP(r.RemoteAddr), set) {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/http/access_test.go
+++ b/internal/http/access_test.go
@@ -1,0 +1,75 @@
+// ABOUTME: Tests for the API access-control helpers (client IP parsing and the
+// ABOUTME: loopback-plus-allowlist decision used by the IP allowlist middleware).
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientIP(t *testing.T) {
+	cases := map[string]string{
+		"1.2.3.4:5678": "1.2.3.4",
+		"[::1]:8080":   "::1",
+		"127.0.0.1":    "127.0.0.1", // bare host, no port
+	}
+	for in, want := range cases {
+		if got := clientIP(in); got != want {
+			t.Errorf("clientIP(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIPAllowed(t *testing.T) {
+	allowed := toIPSet([]string{"192.168.1.50"})
+
+	if !ipAllowed("127.0.0.1", allowed) {
+		t.Error("loopback IPv4 should always be allowed")
+	}
+	if !ipAllowed("::1", allowed) {
+		t.Error("loopback IPv6 should always be allowed")
+	}
+	if !ipAllowed("192.168.1.50", allowed) {
+		t.Error("configured IP should be allowed")
+	}
+	if ipAllowed("192.168.1.99", allowed) {
+		t.Error("unlisted IP should be denied")
+	}
+}
+
+func TestIPAllowedEmptyListIsLoopbackOnly(t *testing.T) {
+	empty := toIPSet(nil)
+
+	if !ipAllowed("127.0.0.1", empty) {
+		t.Error("loopback should be allowed with an empty allowlist")
+	}
+	if ipAllowed("192.168.1.50", empty) {
+		t.Error("empty allowlist must reject any non-loopback IP")
+	}
+}
+
+func TestIPAllowlistMiddleware(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := ipAllowlist([]string{"203.0.113.7"})(next)
+
+	cases := []struct {
+		remoteAddr string
+		wantStatus int
+	}{
+		{"127.0.0.1:1234", http.StatusOK},
+		{"203.0.113.7:1234", http.StatusOK},
+		{"203.0.113.8:1234", http.StatusForbidden},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, "/api/getrelays", nil)
+		req.RemoteAddr = tc.remoteAddr
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != tc.wantStatus {
+			t.Errorf("RemoteAddr %s: got status %d, want %d", tc.remoteAddr, rec.Code, tc.wantStatus)
+		}
+	}
+}

--- a/internal/http/http-server.go
+++ b/internal/http/http-server.go
@@ -13,7 +13,13 @@ import (
 )
 
 type ServerConfig struct {
-	Port int64
+	Port int64 `json:"port"`
+	// AllowedIPs lists client IPs (besides loopback) that may reach the API.
+	// Empty means loopback-only.
+	AllowedIPs []string `json:"allowed_ips"`
+	// AllowedOrigins lists the CORS origins permitted to call the API. Empty
+	// falls back to localhost origins.
+	AllowedOrigins []string `json:"allowed_origins"`
 }
 
 type HttpServer struct {
@@ -25,7 +31,7 @@ type HttpServer struct {
 }
 
 func (s *HttpServer) Routes(c *Controller, port string) {
-	s.Router = routes(c, port)
+	s.Router = routes(c, port, s.Server)
 }
 
 // @title Nostr Reader API

--- a/internal/http/routes.go
+++ b/internal/http/routes.go
@@ -10,17 +10,24 @@ import (
 	httpSwagger "github.com/swaggo/http-swagger"
 )
 
-func routes(c *Controller, port string) *chi.Mux {
+func routes(c *Controller, port string, cfg *ServerConfig) *chi.Mux {
 	router := chi.NewRouter()
+
+	// Only loopback and explicitly allowed client IPs may reach the API.
+	router.Use(ipAllowlist(cfg.AllowedIPs))
 
 	router.Use(middleware.Logger)
 	router.Use(middleware.Recoverer)
 	router.Use(render.SetContentType(render.ContentTypeJSON))
 
+	// Restrict CORS to configured origins; default to localhost when unset.
+	allowedOrigins := cfg.AllowedOrigins
+	if len(allowedOrigins) == 0 {
+		allowedOrigins = []string{"http://localhost:*", "http://127.0.0.1:*"}
+	}
+
 	router.Use(cors.Handler(cors.Options{
-		// AllowedOrigins:   []string{"https://foo.com"}, // Use this to allow specific origin hosts
-		AllowedOrigins: []string{"https://*", "http://*"},
-		// AllowOriginFunc:  func(r *http.Request, origin string) bool { return true },
+		AllowedOrigins:   allowedOrigins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{"Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization", "Accept", "Origin", "Cache-Control", "X-Requested-With"},
 		ExposedHeaders:   []string{"Link"},


### PR DESCRIPTION
The API previously allowed any origin with credentials and any client. Add access control driven by config.json:

- server.allowed_ips: client IPs (besides loopback) permitted to reach the API. An IP allowlist middleware returns 403 for anything else; an empty list means loopback-only.
- server.allowed_origins: CORS origins permitted to call the API. Empty falls back to localhost origins instead of the previous wildcard.

Loopback is always allowed so the local-only setup keeps working with empty lists. Adds unit tests for client IP parsing and the allowlist decision, and documents the new keys in config.json.dist.

Closes #4