### PR TITLE
fix: guard slice indexing against short/empty input

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/nbd-wtf/go-nostr/nip19"
@@ -74,7 +75,7 @@ func LoadConfig() (*Config, error) {
 
 	var pubKey string
 
-	if cfg.Nostr.PrivateKey[:4] == "nsec" {
+	if strings.HasPrefix(cfg.Nostr.PrivateKey, "nsec") {
 		if _, s, err := nip19.Decode(cfg.Nostr.PrivateKey); err == nil {
 			if pubKey, err = nostr.GetPublicKey(s.(string)); err != nil {
 				return nil, err

--- a/internal/http/controllers.go
+++ b/internal/http/controllers.go
@@ -443,7 +443,7 @@ func (c *Controller) Follow() http.HandlerFunc {
 		w.Header().Set("Access-Control-Allow-Origin", "*") // for CORS
 		w.WriteHeader(http.StatusOK)
 
-		if user.Pubkey[0:4] == "npub" {
+		if strings.HasPrefix(user.Pubkey, "npub") {
 			prefix, value, err := nip19.Decode(user.Pubkey)
 			if err != nil {
 				log.Println(prefix, value, err)
@@ -1208,9 +1208,15 @@ func (c *Controller) SearchProfiles() http.HandlerFunc {
 
 		//var err error
 		searchStr := r.URL.Query().Get("q")
+		if searchStr == "" {
+			response.Status = "error"
+			response.Message = "missing search query"
+			render.JSON(w, r, response)
+			return
+		}
 		var pubkey string
 		pubkey = searchStr
-		if searchStr[0:4] == "npub" {
+		if strings.HasPrefix(searchStr, "npub") {
 			prefix, val, err := nip19.Decode(searchStr)
 			if err != nil {
 				response.Status = "error"

--- a/internal/tag/tag.go
+++ b/internal/tag/tag.go
@@ -29,9 +29,12 @@ func ProcessTags(ev *nostr.Event, pubkey string) (etags []string, ptags []string
 	hasNotification = false
 	hasRootOrReplyTag := false
 	for _, tag := range ev.Tags {
+		if len(tag) == 0 {
+			continue
+		}
 		switch {
 		case tag[0] == "e":
-			if len(tag) < 1 || len(tag[1]) != 64 {
+			if len(tag) < 2 || len(tag[1]) != 64 {
 				continue
 			} else {
 				etags = append(etags, tag[1])
@@ -47,7 +50,7 @@ func ProcessTags(ev *nostr.Event, pubkey string) (etags []string, ptags []string
 				hasRootOrReplyTag = true
 			}
 		case tag[0] == "p":
-			if len(tag) < 1 || len(tag[1]) != 64 {
+			if len(tag) < 2 || len(tag[1]) != 64 {
 				log.Println("Tag:: P# tag not valid: ", tag)
 				continue
 			} else {


### PR DESCRIPTION
Several string slices were indexed without a length check, so short or malformed input panicked.

- tag.ProcessTags: skip empty tags before reading tag[0]; the e/p checks now require len(tag) < 2 (they read tag[1]).
- controllers Follow / SearchProfiles: use strings.HasPrefix instead of slicing [0:4]; SearchProfiles returns an error for an empty q query.
- config.LoadConfig: use strings.HasPrefix instead of PrivateKey[:4].

Closes #5