### PR TITLE
fix: guard edge-case panics (empty resultset, nil relay, Vote.Scan)

### DIFF
--- a/internal/db/entities.go
+++ b/internal/db/entities.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"database/sql/driver"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -200,7 +201,16 @@ const (
 )
 
 func (p *Vote) Scan(value interface{}) error {
-	*p = Vote(value.([]byte))
+	switch v := value.(type) {
+	case []byte:
+		*p = Vote(v)
+	case string:
+		*p = Vote(v)
+	case nil:
+		*p = ""
+	default:
+		return fmt.Errorf("unsupported type for Vote: %T", value)
+	}
 	return nil
 }
 

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -471,7 +471,9 @@ func (st *Storage) initPaging(p *Pagination, options Options) {
 				Limit(30).
 				Find(&notesAndProfiles)
 
-			p.Cursor = notesAndProfiles[len(notesAndProfiles)-1].ID
+			if len(notesAndProfiles) > 0 {
+				p.Cursor = notesAndProfiles[len(notesAndProfiles)-1].ID
+			}
 		}
 	}
 }

--- a/internal/nostr/wrapper.go
+++ b/internal/nostr/wrapper.go
@@ -68,7 +68,7 @@ func (wrapper *Wrapper) Do(ctx context.Context, r db.Relay, f func(context.Conte
 
 			relay, err := nostr.RelayConnect(ctx, relayUrl)
 			if err != nil {
-				slog.Info("can't connect to relay: " + relay.URL)
+				slog.Info("can't connect to relay: " + relayUrl)
 				return
 			}
 


### PR DESCRIPTION
- initPaging: only set the cursor when the query returned rows; notesAndProfiles[len-1] panicked on an empty result.
- wrapper.Do: on a RelayConnect failure relay is nil, so logging relay.URL panicked on the error path; log the relayUrl loop var.
- Vote.Scan: replace the unchecked value.([]byte) assertion with a type switch handling []byte, string and nil.

Closes #7