### PR TITLE
cleanup: fix main startup/shutdown lifecycle

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -54,7 +54,6 @@ func main() {
 	done := make(chan bool, 1)
 	go func() {
 		sig := <-exitChan
-		logFile.Close()
 		fmt.Println(sig)
 		done <- true
 	}()
@@ -62,6 +61,7 @@ func main() {
 	go func() {
 		<-done
 		fmt.Println("Closing app")
+		logFile.Close()
 		os.Exit(0)
 	}()
 
@@ -112,7 +112,7 @@ func main() {
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		log.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	cfg.Interval = uint(*syncIntervalPtr)
@@ -137,7 +137,7 @@ func main() {
 
 	if err != nil {
 		log.Println(err.Error())
-		os.Exit(0)
+		os.Exit(1)
 	}
 
 	if cleanStorage {


### PR DESCRIPTION
- Close the log file exactly once on shutdown: move logFile.Close() from the signal goroutine to just before os.Exit in the shutdown goroutine. os.Exit skips deferred calls, so the deferred Close only covers the normal-return path; the two paths are mutually exclusive.
- Use a non-zero exit code (os.Exit(1)) when config loading or the database connection setup fails, instead of os.Exit(0).

Closes #14