### PR TITLE
cleanup: fix typos and rename gargabe JSON tag to garbage

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -88,7 +88,7 @@ const docTemplate = `{
                 "tags": [
                     "user"
                 ],
-                "summary": "Block an anoying user",
+                "summary": "Block an annoying user",
                 "parameters": [
                     {
                         "description": "Body for the retrieval of data",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -82,7 +82,7 @@
                 "tags": [
                     "user"
                 ],
-                "summary": "Block an anoying user",
+                "summary": "Block an annoying user",
                 "parameters": [
                     {
                         "description": "Body for the retrieval of data",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -173,7 +173,7 @@ paths:
           description: error
           schema:
             type: string
-      summary: Block an anoying user
+      summary: Block an annoying user
       tags:
       - user
   /api/bookmark:

--- a/internal/db/entities.go
+++ b/internal/db/entities.go
@@ -18,7 +18,7 @@ type Event struct {
 	Profile  Profile           `json:"profile"`
 	Etags    []string          `json:"-"`
 	Ptags    []string          `json:"-"`
-	Garbage  bool              `json:"gargabe"`
+	Garbage  bool              `json:"garbage"`
 	Children map[string]*Event `json:"children"`
 	Tree     int64             `json:"tree"`
 	RootId   string            `json:"-"`

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -38,7 +38,7 @@ type DbConfig struct {
 }
 
 /**
- * We neede an active database connection object.
+ * We need an active database connection object.
  * The filter is used for certain words in de posts we want to filter out, because they can be spam
  */
 type Storage struct {
@@ -200,7 +200,7 @@ func (st *Storage) SaveProfiles(ctx context.Context, evs []*Event) error {
 
 /**
  * Save the events, mostly notes. Ignore duplicate events based on unique event id
- * This will normalize the content tag of the events with all the unwanted markup (Myaby put this in a helper function)
+ * This will normalize the content tag of the events with all the unwanted markup (Maybe put this in a helper function)
  */
 func (st *Storage) SaveEvents(ctx context.Context, evs []*Event) (pubkeys []string, missingEventIds []string, err error) {
 	pubkeys = make([]string, 0)

--- a/internal/http/controllers.go
+++ b/internal/http/controllers.go
@@ -373,7 +373,7 @@ func (c *Controller) SyncNote() http.HandlerFunc {
 }
 
 // BlockUser godoc
-// @Summary      Block an anoying user
+// @Summary      Block an annoying user
 // @Description  Block user
 // @Tags         user
 // @Accept       json
@@ -1032,7 +1032,7 @@ func (c *Controller) Publish() http.HandlerFunc {
 				slog.Warn(logger.GetCallerInfo(1)+"cannot broadcast", "error", err.Error())
 			}
 			if !success {
-				slog.Warn(logger.GetCallerInfo(1) + "cannot broadcast succesfully")
+				slog.Warn(logger.GetCallerInfo(1) + "cannot broadcast successfully")
 			}
 			wg.Done()
 		}(ctx, c, &postEv)

--- a/internal/http/link-preview.go
+++ b/internal/http/link-preview.go
@@ -137,7 +137,7 @@ func URLPreview(ctx context.Context, url string) (map[string]interface{}, error)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return map[string]interface{}{"url": url, "data": nil, "status": "error", "respcode": fmt.Sprint(resp.StatusCode), "error": "request not succesfull"}, errors.New("request not succesfull " + strconv.Itoa(resp.StatusCode))
+		return map[string]interface{}{"url": url, "data": nil, "status": "error", "respcode": fmt.Sprint(resp.StatusCode), "error": "request not successful"}, errors.New("request not successful " + strconv.Itoa(resp.StatusCode))
 	}
 
 	contentType := resp.Header.Get("Content-type")

--- a/internal/nostr/wrapper.go
+++ b/internal/nostr/wrapper.go
@@ -424,7 +424,7 @@ func (wrapper *Wrapper) DoPublishMetaData(ctx context.Context, user *db.Profile)
 		if err != nil {
 			slog.Error(relay.URL, "error", err)
 		} else {
-			slog.Info("Publish to:", "ralay", relay.URL)
+			slog.Info("Publish to:", "relay", relay.URL)
 			success.Add(1)
 		}
 		return true


### PR DESCRIPTION
- entities.go: rename the Event JSON tag "gargabe" -> "garbage". BREAKING: the API response field name changes; the frontend must be updated to read "garbage".
- Fix misspelled strings/comments: "ralay" -> "relay", "succesfull" ->
  "successful", "succesfully" -> "successfully", "anoying" -> "annoying", "neede" -> "need", "Myaby" -> "Maybe".
- Update the generated swagger docs (docs.go, swagger.json, swagger.yaml) to match the corrected @Summary annotation.

Closes #15