### PR TITLE
@

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ log.txt
 *.test
 *.db
 
+.codegraph

--- a/internal/http/controllers.go
+++ b/internal/http/controllers.go
@@ -835,7 +835,24 @@ func (c *Controller) GetNewNotesCount() http.HandlerFunc {
 		response.Message = "new notes count"
 		response.Context = p.Context
 
-		count, err := c.Db.GetNewNotesCount(ctx, p.Cursor, options)
+		// Count notes newer than the last-seen id, not newer than the cursor.
+		// The cursor is the lower bound of the current page, so every note on
+		// screen already has id > cursor — counting against it overstates the
+		// "new notes" badge by (part of) the current page. The last-seen id
+		// (MAX(note_id) from the seen table) only excludes notes already shown.
+		lastSeenID, err := c.Db.GetLastSeenID(ctx)
+		if err != nil {
+			response.Status = "error"
+			response.Message = err.Error()
+			response.Data = "0"
+
+			if err = json.NewEncoder(w).Encode(&response); err != nil {
+				panic(err)
+			}
+			return
+		}
+
+		count, err := c.Db.GetNewNotesCount(ctx, uint64(lastSeenID), options)
 
 		response.Data = fmt.Sprintf("%d", count)
 


### PR DESCRIPTION
fix: count new notes against last-seen id instead of cursor

GetNewNotesCount counted notes with id > cursor, but the cursor is the lower bound of the current page, so every note already on screen has id > cursor. The "new notes" badge therefore overstated the count by (part of) the current page even when nothing new had arrived.

Use GetLastSeenID() (MAX(note_id) from the seen table) as the lower bound so only not-yet-seen notes are counted. The client is unchanged. @