### PR TITLE
feat: branch-aware fingerprint so copied replies dedup per thread

### DIFF
--- a/internal/db/fingerprint.go
+++ b/internal/db/fingerprint.go
@@ -1,5 +1,5 @@
-// ABOUTME: Content fingerprint for note deduplication: a sha256 over the
-// ABOUTME: author pubkey and content, identifying reposts of identical text.
+// ABOUTME: Content fingerprints for note deduplication: a sha256 over the
+// ABOUTME: author and content, branch-aware for replies, plain for root notes.
 package db
 
 import (
@@ -10,7 +10,23 @@ import (
 // contentFingerprint returns the sha256 hex digest of pubkey + content. The
 // same author posting identical content yields the same fingerprint, even when
 // the events have different ids, which is what lets us deduplicate reposts.
+// This is the fingerprint for root notes; replies use replyFingerprint.
 func contentFingerprint(pubkey, content string) string {
 	hash := sha256.Sum256([]byte(pubkey + content))
+	return fmt.Sprintf("%x", hash[:])
+}
+
+// replyFingerprint returns the sha256 hex digest identifying a reply for
+// deduplication. It folds the root and reply event ids into the hash so the
+// same author copying identical text into a different branch yields a distinct
+// fingerprint, instead of being dropped as a false duplicate of the original
+// reply. Identical text in the exact same branch still collides, so genuine
+// reposts keep deduplicating.
+//
+// The '|' separator disambiguates the fields: pubkey and the event ids are
+// fixed-length hex (or empty) and cannot contain '|', and content comes last,
+// so free-form content can never be confused with a thread id.
+func replyFingerprint(pubkey, content, rootTag, replyTag string) string {
+	hash := sha256.Sum256([]byte(pubkey + "|" + rootTag + "|" + replyTag + "|" + content))
 	return fmt.Sprintf("%x", hash[:])
 }

--- a/internal/db/fingerprint_test.go
+++ b/internal/db/fingerprint_test.go
@@ -39,3 +39,61 @@ func TestContentFingerprintProperties(t *testing.T) {
 		t.Error("different pubkey should yield a different fingerprint")
 	}
 }
+
+func TestReplyFingerprintDiffersByRoot(t *testing.T) {
+	// The same author copying identical text into a reply under a different
+	// root must not collide, otherwise the copy is dropped as a false
+	// duplicate and never shows up in the correct thread.
+	a := replyFingerprint("npub1", "same text", "root1", "")
+	b := replyFingerprint("npub1", "same text", "root2", "")
+	if a == b {
+		t.Error("same text under different roots must not share a fingerprint")
+	}
+}
+
+func TestReplyFingerprintDiffersByReplyParent(t *testing.T) {
+	// Same root, different immediate parent must also be distinct so a reply
+	// re-aimed at another post in the same thread is kept.
+	a := replyFingerprint("npub1", "same text", "root", "parent1")
+	b := replyFingerprint("npub1", "same text", "root", "parent2")
+	if a == b {
+		t.Error("same text under different parents must not share a fingerprint")
+	}
+}
+
+func TestReplyFingerprintGenuineDuplicateCollides(t *testing.T) {
+	// A genuine repost — identical text in the exact same branch — must still
+	// collide so the deduplication keeps working.
+	a := replyFingerprint("npub1", "same text", "root", "parent")
+	b := replyFingerprint("npub1", "same text", "root", "parent")
+	if a != b {
+		t.Error("identical reply in the same branch must share a fingerprint so it dedups")
+	}
+}
+
+func TestReplyFingerprintProperties(t *testing.T) {
+	fp := replyFingerprint("npub1", "hello", "root", "parent")
+
+	if len(fp) != 64 {
+		t.Errorf("fingerprint length = %d, want 64 hex chars", len(fp))
+	}
+	// Different author yields a different fingerprint.
+	if fp == replyFingerprint("npub2", "hello", "root", "parent") {
+		t.Error("different pubkey should yield a different fingerprint")
+	}
+	// Different content yields a different fingerprint.
+	if fp == replyFingerprint("npub1", "hallo", "root", "parent") {
+		t.Error("different content should yield a different fingerprint")
+	}
+}
+
+func TestReplyFingerprintFieldBoundaryUnambiguous(t *testing.T) {
+	// Moving text across the content/thread-id boundary must change the
+	// fingerprint: the separators keep the fixed-length hex ids and the
+	// free-form content from bleeding into one another.
+	a := replyFingerprint("npub1", "abc", "def", "")
+	b := replyFingerprint("npub1", "abcdef", "", "")
+	if a == b {
+		t.Error("content and thread ids must not be confusable")
+	}
+}

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -304,7 +304,13 @@ func (st *Storage) SaveNote(ctx context.Context, event *Event) (Note, []string, 
 		return Note{}, nil, err
 	}
 
+	// Root notes deduplicate on author + content. Replies additionally fold in
+	// their root and reply ids, so the same text copied into another branch is
+	// kept instead of being dropped as a false duplicate of the first reply.
 	fingerprint := contentFingerprint(ev.PubKey, ev.Content)
+	if !isRoot {
+		fingerprint = replyFingerprint(ev.PubKey, ev.Content, tree.RootTag, tree.ReplyTag)
+	}
 
 	newUUID, _ := uuid.NewV7()
 	note := Note{}


### PR DESCRIPTION
## Problem

A reply copied verbatim into another thread was dropped as a duplicate of the
original reply, because the content fingerprint only hashed `pubkey + content`.
Copying the text of a misplaced reply onto the correct root therefore made it
vanish from the right branch.

## Fix

Replies now fold their root and reply event ids into the fingerprint, so the
same text under a different branch is a distinct note. Root notes are unchanged:
`ProcessTags` leaves their root/reply tags empty, so they keep hashing
`pubkey + content` exactly as before and stay byte-compatible with existing
rows. Identical text in the same branch still collides, so genuine reposts keep
deduplicating.

Only new notes are affected; existing rows keep their stored hash.

## Tests

- `replyFingerprint` differs for a different root and for a different parent, and
  is stable for a genuine duplicate (still collides).
- Field-boundary test: content and thread ids cannot be confused for one another.
- Full suite green, `go vet` clean.
