### PR TITLE
chore: bump version to 0.1.0

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -23,7 +23,7 @@ import (
 
 const name = "nostr-reader"
 
-const version = "0.0.10"
+const version = "0.1.0"
 
 func getFireSignalsChannel() chan os.Signal {
 


### PR DESCRIPTION
Sync the `version` constant in `cmd/api/main.go` with the upcoming `v0.1.0`
release tag, so the binary's `--version` output matches the tag.

This release contains:

- Branch-aware reply deduplication (#33).
- New-notes count measured against the last-seen id instead of the page cursor.
