### PR TITLE
feat: add configurable max note age threshold for ingest

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"amavis442/nostr-reader/internal/config"
 	"amavis442/nostr-reader/internal/db"
+	domain "amavis442/nostr-reader/internal/domain"
 	"amavis442/nostr-reader/internal/http"
 	wrapper "amavis442/nostr-reader/internal/nostr"
 	"context"
@@ -23,7 +24,7 @@ import (
 
 const name = "nostr-reader"
 
-const version = "0.1.0"
+const version = "0.1.1"
 
 func getFireSignalsChannel() chan os.Signal {
 
@@ -121,6 +122,10 @@ func main() {
 		cfg.Interval = 1
 	}
 
+	if cfg.MaxNoteAge == nil {
+		cfg.MaxNoteAge = &domain.MaxNoteAge{Days: 7}
+	}
+
 	slog.Info(fmt.Sprintf("Your public key is: %s", cfg.Nostr.PubKey))
 	slog.Info(fmt.Sprintf("Your npub is: %s", cfg.Nostr.Npub))
 
@@ -164,7 +169,7 @@ func main() {
 			case tm := <-ticker.C:
 				slog.Info("The Current time is", "time", tm)
 				wg.Add(1)
-				go intervalTask(&wg, ctx, &st, &nostrWrapper, 120, *disableSyncPtr)
+				go intervalTask(&wg, ctx, &st, &nostrWrapper, cfg.MaxNoteAge.Days, 120, *disableSyncPtr)
 			}
 		}
 	}()
@@ -174,13 +179,14 @@ func main() {
 	httpServer.Server = cfg.Server
 	httpServer.Database = &st
 	httpServer.Nostr = &nostrWrapper
+	httpServer.MaxNoteAge = cfg.MaxNoteAge
 
 	httpServer.Start()
 
 	wg.Wait()
 }
 
-func intervalTask(wg *sync.WaitGroup, ctx context.Context, st *db.Storage, nostrWrapper *wrapper.Wrapper, timeOut int, syncDisabled bool) {
+func intervalTask(wg *sync.WaitGroup, ctx context.Context, st *db.Storage, nostrWrapper *wrapper.Wrapper, maxAgeDays int, timeOut int, syncDisabled bool) {
 	if syncDisabled {
 		return
 	}
@@ -198,7 +204,7 @@ func intervalTask(wg *sync.WaitGroup, ctx context.Context, st *db.Storage, nostr
 	filter := nostrWrapper.GetEventData(createdAt, false)
 	evs := nostrWrapper.GetEvents(ctx, filter)
 
-	_, missingEventIds, err := st.SaveEvents(ctx, evs)
+	_, missingEventIds, err := st.SaveEvents(ctx, evs, maxAgeDays) // notes older than maxAgeDays are ignored
 	if err != nil {
 		slog.Error(err.Error())
 	}
@@ -211,7 +217,7 @@ func intervalTask(wg *sync.WaitGroup, ctx context.Context, st *db.Storage, nostr
 		}
 		evs := nostrWrapper.GetEvents(ctx, filter)
 
-		_, _, err := st.SaveEvents(ctx, evs)
+		_, _, err := st.SaveEvents(ctx, evs, maxAgeDays)
 		if err != nil {
 			log.Println(err)
 		}

--- a/config.json.dist
+++ b/config.json.dist
@@ -4,7 +4,11 @@
         "password": "",
         "dbname": "",
         "port": 5432,
-        "host": "localhost"
+        "host": "localhost",
+        "retention": 7
+    },
+    "max_note_age": {
+        "days": 7
     },
     "server": {
         "port": 8080,
@@ -12,7 +16,7 @@
         "allowed_origins": []
     },
     "interval": 5,
-    "nostr': {
+    "nostr": {
 	    "privatekey": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
         "nip05": "https://nostrcheck.me/"
     },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"amavis442/nostr-reader/internal/db"
+	domain "amavis442/nostr-reader/internal/domain"
 	"amavis442/nostr-reader/internal/http"
 	wrapper "amavis442/nostr-reader/internal/nostr"
 	"encoding/json"
@@ -21,11 +22,12 @@ import (
  *
  */
 type Config struct {
-	Database *db.DbConfig
-	Server   *http.ServerConfig
-	Env      string
-	Interval uint
-	Nostr    *wrapper.WrapperConfig
+	Database   *db.DbConfig
+	Server     *http.ServerConfig
+	Env        string
+	Interval   uint
+	Nostr      *wrapper.WrapperConfig
+	MaxNoteAge *domain.MaxNoteAge `json:"max_note_age"`
 }
 
 func configDir() (string, error) {

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -28,12 +28,12 @@ import (
 )
 
 type DbConfig struct {
-	User      string
-	Password  string
-	Dbname    string
-	Port      int
-	Host      string
-	Retention int
+	User      string `json:"user"`
+	Password  string `json:"password"`
+	Dbname    string `json:"dbname"`
+	Port      int    `json:"port"`
+	Host      string `json:"host"`
+	Retention int    `json:"retention"`
 }
 
 /**
@@ -201,12 +201,14 @@ func (st *Storage) SaveProfiles(ctx context.Context, evs []*Event) error {
  * Save the events, mostly notes. Ignore duplicate events based on unique event id
  * This will normalize the content tag of the events with all the unwanted markup (Maybe put this in a helper function)
  */
-func (st *Storage) SaveEvents(ctx context.Context, evs []*Event) (pubkeys []string, missingEventIds []string, err error) {
+func (st *Storage) SaveEvents(ctx context.Context, evs []*Event, maxAgeDays int) (pubkeys []string, missingEventIds []string, err error) {
 	pubkeys = make([]string, 0)
 	missingEventIds = make([]string, 0)
+	past := time.Now().AddDate(0, 0, -maxAgeDays)
 
 	for _, ev := range evs {
-		if ev.Event.CreatedAt.Time().Unix() > time.Now().Unix() { // Ignore events with timestamp in the future.
+
+		if ev.Event.CreatedAt.Time().Unix() > time.Now().Unix() || ev.Event.CreatedAt.Time().Unix() < past.Unix() { // Ignore events with timestamp in the future or to far in the past.
 			continue
 		}
 

--- a/internal/domain/entity.go
+++ b/internal/domain/entity.go
@@ -1,0 +1,7 @@
+// ABOUTME: Domain types shared across packages without external dependencies.
+// ABOUTME: MaxNoteAge bounds how old an incoming note may be before it is ignored on ingest.
+package domain
+
+type MaxNoteAge struct {
+	Days int `json:"days"`
+}

--- a/internal/http/controllers.go
+++ b/internal/http/controllers.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"amavis442/nostr-reader/internal/db"
+	domain "amavis442/nostr-reader/internal/domain"
 	"amavis442/nostr-reader/internal/logger"
 	wrapper "amavis442/nostr-reader/internal/nostr"
 	"context"
@@ -21,9 +22,10 @@ import (
 )
 
 type Controller struct {
-	Pubkey string
-	Db     *db.Storage
-	Nostr  *wrapper.Wrapper
+	Pubkey     string
+	Db         *db.Storage
+	Nostr      *wrapper.Wrapper
+	MaxNoteAge *domain.MaxNoteAge
 }
 
 /**
@@ -301,7 +303,7 @@ func (c *Controller) StartSync() http.HandlerFunc {
 		evs := c.Nostr.GetEvents(ctx, filter)
 		var pubkeys = make([]string, 0)
 		var err error
-		pubkeys, _, err = c.Db.SaveEvents(ctx, evs)
+		pubkeys, _, err = c.Db.SaveEvents(ctx, evs, c.MaxNoteAge.Days)
 		if err != nil {
 			response.Status = "error"
 			response.Message = err.Error()
@@ -354,7 +356,7 @@ func (c *Controller) SyncNote() http.HandlerFunc {
 
 		evs := c.Nostr.GetEvents(ctx, filter)
 
-		c.Db.SaveEvents(ctx, evs)
+		c.Db.SaveEvents(ctx, evs, c.MaxNoteAge.Days)
 		ev, _ := c.Db.FindEvent(ctx, j.ID)
 
 		log.Println("Need to get it", j.ID, filter)
@@ -936,7 +938,7 @@ func (c *Controller) SearchEvent() http.HandlerFunc {
 
 			evs := c.Nostr.GetEvents(ctx, filter)
 
-			c.Db.SaveEvents(ctx, evs)
+			c.Db.SaveEvents(ctx, evs, c.MaxNoteAge.Days)
 
 			log.Println("Need to get it", j.ID, filter)
 		}

--- a/internal/http/http-server.go
+++ b/internal/http/http-server.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"amavis442/nostr-reader/internal/db"
+	domain "amavis442/nostr-reader/internal/domain"
 	wrapper "amavis442/nostr-reader/internal/nostr"
 	"fmt"
 	"log/slog"
@@ -23,11 +24,12 @@ type ServerConfig struct {
 }
 
 type HttpServer struct {
-	DevMode  bool
-	Server   *ServerConfig
-	Database *db.Storage
-	Nostr    *wrapper.Wrapper
-	Router   *chi.Mux
+	DevMode    bool
+	Server     *ServerConfig
+	Database   *db.Storage
+	Nostr      *wrapper.Wrapper
+	Router     *chi.Mux
+	MaxNoteAge *domain.MaxNoteAge
 }
 
 func (s *HttpServer) Routes(c *Controller, port string) {
@@ -53,6 +55,7 @@ func (s *HttpServer) Start() {
 	c.Pubkey = s.Nostr.Cfg.PubKey
 	c.Db = s.Database
 	c.Nostr = s.Nostr
+	c.MaxNoteAge = s.MaxNoteAge
 
 	var port string = "8080"
 	if s.Server.Port > 0 {


### PR DESCRIPTION
Closes #35

## Summary

Introduces a dependency-free `domain.MaxNoteAge` type so notes older than a configurable number of days are ignored at **ingest** time, replacing the hard-coded 7-day cutoff in `SaveEvents`. This is distinct from database retention cleanup (`DbConfig.Retention` + `Clean()`), which the previous naming conflated.

## Changes

- New leaf package `internal/domain` with `MaxNoteAge{ Days int }` (avoids an import cycle, since `config` already imports `db`/`http`/`nostr`).
- `Config.MaxNoteAge` loaded from a top-level `max_note_age` key in `config.json` (explicit `json:"max_note_age"` tag).
- `SaveEvents` takes a `maxAgeDays int` parameter; ignores events older than the cutoff (and still ignores future timestamps).
- Threshold wired through `HttpServer` and `Controller` for the sync endpoints and through `intervalTask` for the background sync; defaults to 7 days when the config block is omitted.
- `config.json.dist` now documents both `max_note_age` (ingest threshold) and `database.retention` (cleanup window).

## Verification

`go build ./...`, `go vet ./...` and `go test ./...` all pass clean.