### PR TITLE
chore: pagination cleanup and cursor/direction refactor

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -9,16 +9,7 @@ const docTemplate = `{
     "info": {
         "description": "{{escape .Description}}",
         "title": "{{.Title}}",
-        "termsOfService": "http://swaggerouter.io/terms/",
-        "contact": {
-            "name": "API Support",
-            "url": "http://www.swaggerouter.io/support",
-            "email": "support@swaggerouter.io"
-        },
-        "license": {
-            "name": "Apache 2.0",
-            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-        },
+        "contact": {},
         "version": "{{.Version}}"
     },
     "host": "{{.Host}}",
@@ -44,7 +35,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Relay"
+                            "$ref": "#/definitions/db.Relay"
                         }
                     }
                 ],
@@ -52,7 +43,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -96,7 +87,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Pubkey"
+                            "$ref": "#/definitions/http.Pubkey"
                         }
                     }
                 ],
@@ -104,7 +95,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -148,7 +139,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.BookMark"
+                            "$ref": "#/definitions/http.BookMark"
                         }
                     }
                 ],
@@ -156,7 +147,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -200,7 +191,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Pubkey"
+                            "$ref": "#/definitions/http.Pubkey"
                         }
                     }
                 ],
@@ -208,7 +199,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -249,7 +240,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -293,7 +284,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.PageRequest"
+                            "$ref": "#/definitions/http.PageRequest"
                         }
                     }
                 ],
@@ -301,7 +292,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -342,7 +333,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -383,7 +374,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -479,7 +470,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -575,7 +566,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -616,7 +607,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -657,7 +648,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -701,7 +692,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Msg"
+                            "$ref": "#/definitions/http.Msg"
                         }
                     }
                 ],
@@ -709,7 +700,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -753,7 +744,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.BookMark"
+                            "$ref": "#/definitions/http.BookMark"
                         }
                     }
                 ],
@@ -761,7 +752,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -805,7 +796,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Relay"
+                            "$ref": "#/definitions/db.Relay"
                         }
                     }
                 ],
@@ -813,7 +804,48 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/searchprofiles": {
+            "get": {
+                "description": "Search for profiles",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "profile"
+                ],
+                "summary": "Search for profiles",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -857,7 +889,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Profile"
+                            "$ref": "#/definitions/db.Profile"
                         }
                     }
                 ],
@@ -865,7 +897,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -909,7 +941,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Pubkey"
+                            "$ref": "#/definitions/http.Pubkey"
                         }
                     }
                 ],
@@ -917,7 +949,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -943,90 +975,32 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "main.BookMark": {
-            "type": "object",
-            "properties": {
-                "event_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "main.Msg": {
-            "type": "object",
-            "properties": {
-                "event_id": {
-                    "description": "If it is a reply",
-                    "type": "string"
-                },
-                "msg": {
-                    "type": "string"
-                }
-            }
-        },
-        "main.NullString": {
-            "type": "object",
-            "properties": {
-                "string": {
-                    "type": "string"
-                },
-                "valid": {
-                    "description": "Valid is true if String is not NULL",
-                    "type": "boolean"
-                }
-            }
-        },
-        "main.PageRequest": {
-            "type": "object",
-            "properties": {
-                "context": {
-                    "type": "string"
-                },
-                "cursor": {
-                    "type": "integer"
-                },
-                "next_cursor": {
-                    "type": "integer"
-                },
-                "per_page": {
-                    "type": "integer"
-                },
-                "prev_cursor": {
-                    "type": "integer"
-                },
-                "renew": {
-                    "type": "boolean"
-                },
-                "since": {
-                    "type": "integer"
-                }
-            }
-        },
-        "main.Profile": {
+        "db.Profile": {
             "type": "object",
             "properties": {
                 "about": {
-                    "$ref": "#/definitions/main.NullString"
+                    "type": "string"
                 },
                 "blocked": {
                     "type": "boolean"
                 },
                 "display_name": {
-                    "$ref": "#/definitions/main.NullString"
+                    "type": "string"
                 },
                 "followed": {
                     "type": "boolean"
                 },
                 "lud16": {
-                    "$ref": "#/definitions/main.NullString"
+                    "type": "string"
                 },
                 "name": {
-                    "$ref": "#/definitions/main.NullString"
+                    "type": "string"
                 },
                 "nip05": {
-                    "$ref": "#/definitions/main.NullString"
+                    "type": "string"
                 },
                 "picture": {
-                    "$ref": "#/definitions/main.NullString"
+                    "type": "string"
                 },
                 "pubkey": {
                     "type": "string"
@@ -1041,19 +1015,11 @@ const docTemplate = `{
                     }
                 },
                 "website": {
-                    "$ref": "#/definitions/main.NullString"
-                }
-            }
-        },
-        "main.Pubkey": {
-            "type": "object",
-            "properties": {
-                "pubkey": {
                     "type": "string"
                 }
             }
         },
-        "main.Relay": {
+        "db.Relay": {
             "type": "object",
             "properties": {
                 "read": {
@@ -1070,7 +1036,58 @@ const docTemplate = `{
                 }
             }
         },
-        "main.Response": {
+        "http.BookMark": {
+            "type": "object",
+            "properties": {
+                "event_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "http.Msg": {
+            "type": "object",
+            "properties": {
+                "event_id": {
+                    "description": "If it is a reply",
+                    "type": "string"
+                },
+                "msg": {
+                    "type": "string"
+                }
+            }
+        },
+        "http.PageRequest": {
+            "type": "object",
+            "properties": {
+                "context": {
+                    "type": "string"
+                },
+                "cursor": {
+                    "type": "integer"
+                },
+                "direction": {
+                    "type": "string"
+                },
+                "per_page": {
+                    "type": "integer"
+                },
+                "renew": {
+                    "type": "boolean"
+                },
+                "since": {
+                    "type": "integer"
+                }
+            }
+        },
+        "http.Pubkey": {
+            "type": "object",
+            "properties": {
+                "pubkey": {
+                    "type": "string"
+                }
+            }
+        },
+        "http.Response": {
             "description": "Standard response to return to client",
             "type": "object",
             "properties": {
@@ -1091,12 +1108,12 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "1.0",
-	Host:             "localhost:8080",
-	BasePath:         "/",
+	Version:          "",
+	Host:             "",
+	BasePath:         "",
 	Schemes:          []string{},
-	Title:            "Nostr Reader API",
-	Description:      "Nostr Reader Api.",
+	Title:            "",
+	Description:      "",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,22 +1,8 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "Nostr Reader Api.",
-        "title": "Nostr Reader API",
-        "termsOfService": "http://swaggerouter.io/terms/",
-        "contact": {
-            "name": "API Support",
-            "url": "http://www.swaggerouter.io/support",
-            "email": "support@swaggerouter.io"
-        },
-        "license": {
-            "name": "Apache 2.0",
-            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-        },
-        "version": "1.0"
+        "contact": {}
     },
-    "host": "localhost:8080",
-    "basePath": "/",
     "paths": {
         "/api/addrelay": {
             "post": {
@@ -38,7 +24,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Relay"
+                            "$ref": "#/definitions/db.Relay"
                         }
                     }
                 ],
@@ -46,7 +32,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -90,7 +76,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Pubkey"
+                            "$ref": "#/definitions/http.Pubkey"
                         }
                     }
                 ],
@@ -98,7 +84,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -142,7 +128,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.BookMark"
+                            "$ref": "#/definitions/http.BookMark"
                         }
                     }
                 ],
@@ -150,7 +136,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -194,7 +180,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Pubkey"
+                            "$ref": "#/definitions/http.Pubkey"
                         }
                     }
                 ],
@@ -202,7 +188,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -243,7 +229,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -287,7 +273,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.PageRequest"
+                            "$ref": "#/definitions/http.PageRequest"
                         }
                     }
                 ],
@@ -295,7 +281,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -336,7 +322,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -377,7 +363,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -473,7 +459,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -569,7 +555,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -610,7 +596,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -651,7 +637,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -695,7 +681,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Msg"
+                            "$ref": "#/definitions/http.Msg"
                         }
                     }
                 ],
@@ -703,7 +689,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -747,7 +733,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.BookMark"
+                            "$ref": "#/definitions/http.BookMark"
                         }
                     }
                 ],
@@ -755,7 +741,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -799,7 +785,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Relay"
+                            "$ref": "#/definitions/db.Relay"
                         }
                     }
                 ],
@@ -807,7 +793,48 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/searchprofiles": {
+            "get": {
+                "description": "Search for profiles",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "profile"
+                ],
+                "summary": "Search for profiles",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -851,7 +878,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Profile"
+                            "$ref": "#/definitions/db.Profile"
                         }
                     }
                 ],
@@ -859,7 +886,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -903,7 +930,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/main.Pubkey"
+                            "$ref": "#/definitions/http.Pubkey"
                         }
                     }
                 ],
@@ -911,7 +938,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/main.Response"
+                            "$ref": "#/definitions/http.Response"
                         }
                     },
                     "400": {
@@ -937,90 +964,32 @@
         }
     },
     "definitions": {
-        "main.BookMark": {
-            "type": "object",
-            "properties": {
-                "event_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "main.Msg": {
-            "type": "object",
-            "properties": {
-                "event_id": {
-                    "description": "If it is a reply",
-                    "type": "string"
-                },
-                "msg": {
-                    "type": "string"
-                }
-            }
-        },
-        "main.NullString": {
-            "type": "object",
-            "properties": {
-                "string": {
-                    "type": "string"
-                },
-                "valid": {
-                    "description": "Valid is true if String is not NULL",
-                    "type": "boolean"
-                }
-            }
-        },
-        "main.PageRequest": {
-            "type": "object",
-            "properties": {
-                "context": {
-                    "type": "string"
-                },
-                "cursor": {
-                    "type": "integer"
-                },
-                "next_cursor": {
-                    "type": "integer"
-                },
-                "per_page": {
-                    "type": "integer"
-                },
-                "prev_cursor": {
-                    "type": "integer"
-                },
-                "renew": {
-                    "type": "boolean"
-                },
-                "since": {
-                    "type": "integer"
-                }
-            }
-        },
-        "main.Profile": {
+        "db.Profile": {
             "type": "object",
             "properties": {
                 "about": {
-                    "$ref": "#/definitions/main.NullString"
+                    "type": "string"
                 },
                 "blocked": {
                     "type": "boolean"
                 },
                 "display_name": {
-                    "$ref": "#/definitions/main.NullString"
+                    "type": "string"
                 },
                 "followed": {
                     "type": "boolean"
                 },
                 "lud16": {
-                    "$ref": "#/definitions/main.NullString"
+                    "type": "string"
                 },
                 "name": {
-                    "$ref": "#/definitions/main.NullString"
+                    "type": "string"
                 },
                 "nip05": {
-                    "$ref": "#/definitions/main.NullString"
+                    "type": "string"
                 },
                 "picture": {
-                    "$ref": "#/definitions/main.NullString"
+                    "type": "string"
                 },
                 "pubkey": {
                     "type": "string"
@@ -1035,19 +1004,11 @@
                     }
                 },
                 "website": {
-                    "$ref": "#/definitions/main.NullString"
-                }
-            }
-        },
-        "main.Pubkey": {
-            "type": "object",
-            "properties": {
-                "pubkey": {
                     "type": "string"
                 }
             }
         },
-        "main.Relay": {
+        "db.Relay": {
             "type": "object",
             "properties": {
                 "read": {
@@ -1064,7 +1025,58 @@
                 }
             }
         },
-        "main.Response": {
+        "http.BookMark": {
+            "type": "object",
+            "properties": {
+                "event_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "http.Msg": {
+            "type": "object",
+            "properties": {
+                "event_id": {
+                    "description": "If it is a reply",
+                    "type": "string"
+                },
+                "msg": {
+                    "type": "string"
+                }
+            }
+        },
+        "http.PageRequest": {
+            "type": "object",
+            "properties": {
+                "context": {
+                    "type": "string"
+                },
+                "cursor": {
+                    "type": "integer"
+                },
+                "direction": {
+                    "type": "string"
+                },
+                "per_page": {
+                    "type": "integer"
+                },
+                "renew": {
+                    "type": "boolean"
+                },
+                "since": {
+                    "type": "integer"
+                }
+            }
+        },
+        "http.Pubkey": {
+            "type": "object",
+            "properties": {
+                "pubkey": {
+                    "type": "string"
+                }
+            }
+        },
+        "http.Response": {
             "description": "Standard response to return to client",
             "type": "object",
             "properties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,61 +1,22 @@
-basePath: /
 definitions:
-  main.BookMark:
-    properties:
-      event_id:
-        type: string
-    type: object
-  main.Msg:
-    properties:
-      event_id:
-        description: If it is a reply
-        type: string
-      msg:
-        type: string
-    type: object
-  main.NullString:
-    properties:
-      string:
-        type: string
-      valid:
-        description: Valid is true if String is not NULL
-        type: boolean
-    type: object
-  main.PageRequest:
-    properties:
-      context:
-        type: string
-      cursor:
-        type: integer
-      next_cursor:
-        type: integer
-      per_page:
-        type: integer
-      prev_cursor:
-        type: integer
-      renew:
-        type: boolean
-      since:
-        type: integer
-    type: object
-  main.Profile:
+  db.Profile:
     properties:
       about:
-        $ref: '#/definitions/main.NullString'
+        type: string
       blocked:
         type: boolean
       display_name:
-        $ref: '#/definitions/main.NullString'
+        type: string
       followed:
         type: boolean
       lud16:
-        $ref: '#/definitions/main.NullString'
+        type: string
       name:
-        $ref: '#/definitions/main.NullString'
+        type: string
       nip05:
-        $ref: '#/definitions/main.NullString'
+        type: string
       picture:
-        $ref: '#/definitions/main.NullString'
+        type: string
       pubkey:
         type: string
       uid:
@@ -65,14 +26,9 @@ definitions:
           type: string
         type: array
       website:
-        $ref: '#/definitions/main.NullString'
-    type: object
-  main.Pubkey:
-    properties:
-      pubkey:
         type: string
     type: object
-  main.Relay:
+  db.Relay:
     properties:
       read:
         type: boolean
@@ -83,7 +39,40 @@ definitions:
       write:
         type: boolean
     type: object
-  main.Response:
+  http.BookMark:
+    properties:
+      event_id:
+        type: string
+    type: object
+  http.Msg:
+    properties:
+      event_id:
+        description: If it is a reply
+        type: string
+      msg:
+        type: string
+    type: object
+  http.PageRequest:
+    properties:
+      context:
+        type: string
+      cursor:
+        type: integer
+      direction:
+        type: string
+      per_page:
+        type: integer
+      renew:
+        type: boolean
+      since:
+        type: integer
+    type: object
+  http.Pubkey:
+    properties:
+      pubkey:
+        type: string
+    type: object
+  http.Response:
     description: Standard response to return to client
     properties:
       context:
@@ -94,19 +83,8 @@ definitions:
       status:
         type: string
     type: object
-host: localhost:8080
 info:
-  contact:
-    email: support@swaggerouter.io
-    name: API Support
-    url: http://www.swaggerouter.io/support
-  description: Nostr Reader Api.
-  license:
-    name: Apache 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0.html
-  termsOfService: http://swaggerouter.io/terms/
-  title: Nostr Reader API
-  version: "1.0"
+  contact: {}
 paths:
   /api/addrelay:
     post:
@@ -119,14 +97,14 @@ paths:
         name: Body
         required: true
         schema:
-          $ref: '#/definitions/main.Relay'
+          $ref: '#/definitions/db.Relay'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -153,14 +131,14 @@ paths:
         name: Body
         required: true
         schema:
-          $ref: '#/definitions/main.Pubkey'
+          $ref: '#/definitions/http.Pubkey'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -187,14 +165,14 @@ paths:
         name: Body
         required: true
         schema:
-          $ref: '#/definitions/main.BookMark'
+          $ref: '#/definitions/http.BookMark'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -221,14 +199,14 @@ paths:
         name: Body
         required: true
         schema:
-          $ref: '#/definitions/main.Pubkey'
+          $ref: '#/definitions/http.Pubkey'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -255,7 +233,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -282,14 +260,14 @@ paths:
         name: Body
         required: true
         schema:
-          $ref: '#/definitions/main.PageRequest'
+          $ref: '#/definitions/http.PageRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -316,7 +294,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -343,7 +321,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -409,7 +387,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -475,7 +453,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -502,7 +480,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -529,7 +507,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -556,14 +534,14 @@ paths:
         name: Body
         required: true
         schema:
-          $ref: '#/definitions/main.Msg'
+          $ref: '#/definitions/http.Msg'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -590,14 +568,14 @@ paths:
         name: Body
         required: true
         schema:
-          $ref: '#/definitions/main.BookMark'
+          $ref: '#/definitions/http.BookMark'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -624,14 +602,14 @@ paths:
         name: Body
         required: true
         schema:
-          $ref: '#/definitions/main.Relay'
+          $ref: '#/definitions/db.Relay'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -647,6 +625,33 @@ paths:
       summary: Remove relay
       tags:
       - relay
+  /api/searchprofiles:
+    get:
+      consumes:
+      - application/json
+      description: Search for profiles
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/http.Response'
+        "400":
+          description: error
+          schema:
+            type: string
+        "404":
+          description: error
+          schema:
+            type: string
+        "500":
+          description: error
+          schema:
+            type: string
+      summary: Search for profiles
+      tags:
+      - profile
   /api/setmetadata:
     post:
       consumes:
@@ -658,14 +663,14 @@ paths:
         name: Body
         required: true
         schema:
-          $ref: '#/definitions/main.Profile'
+          $ref: '#/definitions/db.Profile'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:
@@ -692,14 +697,14 @@ paths:
         name: Body
         required: true
         schema:
-          $ref: '#/definitions/main.Pubkey'
+          $ref: '#/definitions/http.Pubkey'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/main.Response'
+            $ref: '#/definitions/http.Response'
         "400":
           description: error
           schema:

--- a/internal/db/entities.go
+++ b/internal/db/entities.go
@@ -95,15 +95,15 @@ type Profile struct {
 	ID          uint           `gorm:"primaryKey" json:"-" db:"id"`
 	UID         uuid.UUID      `gorm:"type:uuid;" db:"uid"`
 	Pubkey      string         `gorm:"index,type:btree;not null;unique;type:varchar(100)" json:"pubkey" db:"pubkey"`
-	Name        NullString     `gorm:"type:varchar(255)" json:"name" db:"name"`
-	About       NullString     `gorm:"type:text" json:"about" db:"about"`
-	Picture     NullString     `gorm:"type:varchar(255)" json:"picture" db:"picture"`
-	Website     NullString     `gorm:"type:varchar(255)" json:"website" db:"website"`
-	Nip05       NullString     `gorm:"type:varchar(255)" json:"nip05" db:"nip05"`
-	Lud16       NullString     `gorm:"type:varchar(255)" json:"lud16" db:"lud16"`
-	DisplayName NullString     `gorm:"type:varchar(255)" json:"display_name" db:"display_name"`
+	Name        NullString     `gorm:"type:varchar(255)" json:"name" db:"name" swaggertype:"string"`
+	About       NullString     `gorm:"type:text" json:"about" db:"about" swaggertype:"string"`
+	Picture     NullString     `gorm:"type:varchar(255)" json:"picture" db:"picture" swaggertype:"string"`
+	Website     NullString     `gorm:"type:varchar(255)" json:"website" db:"website" swaggertype:"string"`
+	Nip05       NullString     `gorm:"type:varchar(255)" json:"nip05" db:"nip05" swaggertype:"string"`
+	Lud16       NullString     `gorm:"type:varchar(255)" json:"lud16" db:"lud16" swaggertype:"string"`
+	DisplayName NullString     `gorm:"type:varchar(255)" json:"display_name" db:"display_name" swaggertype:"string"`
 	Raw         []byte         `gorm:"not null;type:jsonb" json:"-" db:"raw"`
-	Urls        pq.StringArray `gorm:"type:text[];index:idx_profile_urls,type:gin" json:"urls" db:"urls"`
+	Urls        pq.StringArray `gorm:"type:text[];index:idx_profile_urls,type:gin" json:"urls" db:"urls" swaggertype:"array,string"`
 	CreatedAt   sql.NullTime   `gorm:"type:timestamp;default:current_timestamp" json:"-" db:"created_at"`
 	UpdatedAt   sql.NullTime   `gorm:"type:timestamp;default:null" json:"-" db:"updated_at"`
 	Followed    bool           `gorm:"type:bool;default:false;not null" json:"followed" db:"-"`

--- a/internal/db/pagination.go
+++ b/internal/db/pagination.go
@@ -6,6 +6,8 @@ type Pagination struct {
 	Direction string `json:"direction"`
 	PerPage   uint   `json:"per_page,omitempty" query:"per_page"`
 	Since     uint   `json:"since"`
+	HasNext   bool   `json:"has_next"`
+	HasPrev   bool   `json:"has_prev"`
 }
 
 func (p *Pagination) SetCursor(cursor uint64) {

--- a/internal/db/pagination.go
+++ b/internal/db/pagination.go
@@ -2,35 +2,26 @@ package db
 
 // Return to client API
 type Pagination struct {
-	Cursor         uint64 `json:"cursor"`
-	NextCursor     uint64 `json:"next_cursor"`
-	PreviousCursor uint64 `json:"previous_cursor"`
-	PerPage        uint   `json:"per_page,omitempty" query:"per_page"`
-	Since          uint   `json:"since"`
+	Cursor    uint64 `json:"cursor"`
+	Direction string `json:"direction"`
+	PerPage   uint   `json:"per_page,omitempty" query:"per_page"`
+	Since     uint   `json:"since"`
 }
 
 func (p *Pagination) SetCursor(cursor uint64) {
 	p.Cursor = cursor
 }
 
-func (p *Pagination) SetPrev(prev uint64) {
-	p.PreviousCursor = prev
-}
-
-func (p *Pagination) GetPrev() uint64 {
-	return p.PreviousCursor
-}
-
-func (p *Pagination) SetNext(next_cursor uint64) {
-	p.NextCursor = next_cursor
-}
-
-func (p *Pagination) GetNext() uint64 {
-	return p.NextCursor
-}
-
-func (p *Pagination) GetPage() uint64 {
+func (p *Pagination) GetCursor() uint64 {
 	return p.Cursor
+}
+
+func (p *Pagination) SetDirection(direction string) {
+	p.Direction = direction
+}
+
+func (p *Pagination) GetDirection() string {
+	return p.Direction
 }
 
 /*

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -471,23 +471,6 @@ func (st *Storage) GetLastSeenID(ctx context.Context) (int, error) {
 	return maxId, nil
 }
 
-func (st *Storage) initPaging(p *Pagination, options Options) {
-	if p.Cursor == 0 {
-		var notesAndProfiles []NotesAndProfiles
-		if !options.BookMark {
-			st.session().Model(&NotesAndProfiles{}).
-				Where(`id < (SELECT MAX(id) FROM "notes_and_profiles" WHERE followed = @follow and bookmarked = @bookmark)`, sql.Named("follow", options.Follow), sql.Named("bookmark", options.BookMark)).
-				Where("followed = @follow and bookmarked = @bookmark", sql.Named("follow", options.Follow), sql.Named("bookmark", options.BookMark)).
-				Order("id DESC").
-				Limit(30).
-				Find(&notesAndProfiles)
-
-			if len(notesAndProfiles) > 0 {
-				p.Cursor = notesAndProfiles[len(notesAndProfiles)-1].ID
-			}
-		}
-	}
-}
 
 type NotesAndProfiles struct {
 	ID             uint64          `gorm:"type:bigint"`
@@ -548,26 +531,20 @@ func (st *Storage) GetNotes(ctx context.Context, context string, p *Pagination, 
 	if p.Direction == "prev" {
 		state = stateName[StatePrev]
 	}
-	st.initPaging(p, options)
 	slog.Info("State is: ", "state", state)
 
 	tx := st.session().Where("followed = ? and bookmarked = ?", options.Follow, options.BookMark)
 
-	if state == stateName[StateInit] || state == stateName[StateRefresh] {
-		tx = tx.Where("id > ?", p.Cursor).
-			Order("id ASC")
+	switch state {
+	case stateName[StateInit], stateName[StateRefresh]:
+		tx = tx.Order("event_created_at DESC")
+	case stateName[StateNext]:
+		tx = tx.Where("event_created_at > ?", p.Cursor).Order("event_created_at ASC")
+	case stateName[StatePrev]:
+		tx = tx.Where("event_created_at < ?", p.Cursor).Order("event_created_at DESC")
 	}
 
-	if state == stateName[StateNext] {
-		tx = tx.Where("id > ?", p.Cursor).
-			Order("id ASC")
-	}
-	if state == stateName[StatePrev] {
-		tx = tx.Where("id < ?", p.Cursor).
-			Order("id DESC")
-	}
-
-	tx = tx.Limit(int(p.GetPerPage())) // Last one is not shown and only used for the next cursor
+	tx = tx.Limit(int(p.GetPerPage()))
 
 	var rows []NotesAndProfiles
 	tx.Find(&rows)
@@ -575,24 +552,28 @@ func (st *Storage) GetNotes(ctx context.Context, context string, p *Pagination, 
 		return &[]Event{}, nil
 	}
 
+	// Sort DESC by event timestamp for consistent display regardless of query order.
 	sort.Slice(rows, func(i, j int) bool {
-		return rows[i].ID > rows[j].ID
+		return rows[i].EventCreatedAt > rows[j].EventCreatedAt
 	})
 
 	if len(rows) > 0 {
-		maxID := rows[0].ID
-		minID := rows[len(rows)-1].ID
-		p.Cursor = minID
+		maxTS := uint64(rows[0].EventCreatedAt)
+		minTS := uint64(rows[len(rows)-1].EventCreatedAt)
 
-		// A partial page means no more results exist in the direction we were paginating —
-		// no query needed for that side. The opposite direction still requires a check.
+		// Return the oldest timestamp on the page as cursor — the frontend uses it
+		// for "prev" navigation (event_created_at < minTS).
+		// For "next", the frontend extracts the newest timestamp from the event list.
+		p.Cursor = minTS
+
+		// A partial page means no more results in the direction we were paginating.
 		partialPage := len(rows) < int(p.GetPerPage())
 
 		if !partialPage || state == stateName[StatePrev] {
 			var count int64
 			st.session().Model(&NotesAndProfiles{}).
 				Where("followed = ? AND bookmarked = ?", options.Follow, options.BookMark).
-				Where("id > ?", maxID).
+				Where("event_created_at > ?", maxTS).
 				Limit(1).Count(&count)
 			p.HasNext = count > 0
 		}
@@ -601,15 +582,11 @@ func (st *Storage) GetNotes(ctx context.Context, context string, p *Pagination, 
 			var count int64
 			st.session().Model(&NotesAndProfiles{}).
 				Where("followed = ? AND bookmarked = ?", options.Follow, options.BookMark).
-				Where("id < ?", minID).
+				Where("event_created_at < ?", minTS).
 				Limit(1).Count(&count)
 			p.HasPrev = count > 0
 		}
 	}
-
-	sort.Slice(rows, func(i, j int) bool {
-		return rows[i].EventCreatedAt.Time().Unix() > rows[j].EventCreatedAt.Time().Unix()
-	})
 
 	eventMap, keys, seenMap, err := st.procesEventRows(&rows)
 	if err != nil {
@@ -658,16 +635,15 @@ func (st *Storage) GetNotifications(ctx context.Context, p *Pagination) (*[]Even
 	tx := st.session().Model(&Note{}).
 		Joins("JOIN notifications ON (notifications.note_id = notes.id)")
 
-	// Apply the cursor to the driving query so pagination actually advances.
 	switch state {
+	case stateName[StateInit], stateName[StateRefresh]:
+		tx = tx.Order("notes.event_created_at DESC")
 	case stateName[StateNext]:
-		tx = tx.Where("notes.id < ?", p.Cursor)
+		tx = tx.Where("notes.event_created_at < ?", p.Cursor).Order("notes.event_created_at DESC")
 	case stateName[StatePrev]:
-		tx = tx.Where("notes.id > ?", p.Cursor)
-	case stateName[StateRefresh]:
-		tx = tx.Where("notes.id > ?", p.Cursor)
+		tx = tx.Where("notes.event_created_at > ?", p.Cursor).Order("notes.event_created_at ASC")
 	}
-	tx = tx.Order("notes.id DESC").Limit(int(p.GetPerPage()))
+	tx = tx.Limit(int(p.GetPerPage()))
 
 	var notes []Note
 	tx.Find(&notes)
@@ -675,31 +651,26 @@ func (st *Storage) GetNotifications(ctx context.Context, p *Pagination) (*[]Even
 		return &[]Event{}, nil
 	}
 
-	// Cursors track the notification notes themselves (ordered by id DESC):
-	// the last (oldest) id pages forward, the first (newest) id pages back.
+	// Sort DESC by event timestamp for consistent display regardless of query order.
+	sort.Slice(notes, func(i, j int) bool {
+		return notes[i].EventCreatedAt > notes[j].EventCreatedAt
+	})
+
 	perPage := int(p.GetPerPage())
 
-	if len(notes) >= perPage {
-		p.Cursor = uint64(notes[len(notes)-1].ID)
-	}
-	if state != stateName[StateInit] {
-		p.Cursor = uint64(notes[0].ID)
-	}
-
 	if len(notes) > 0 {
-		maxID := uint64(notes[0].ID)
-		minID := uint64(notes[len(notes)-1].ID)
+		maxTS := uint64(notes[0].EventCreatedAt)
+		minTS := uint64(notes[len(notes)-1].EventCreatedAt)
+		p.Cursor = minTS
 
-		// GetNotifications queries in DESC order: "next" goes to lower IDs (older),
-		// "prev" goes to higher IDs (newer). A partial page means no more exist
-		// in the direction we were paginating.
 		partialPage := len(notes) < perPage
 
+		// GetNotifications displays newest first; "next" goes to older (lower timestamps).
 		if !partialPage || state == stateName[StatePrev] {
 			var count int64
 			st.session().Model(&Note{}).
 				Joins("JOIN notifications ON (notifications.note_id = notes.id)").
-				Where("notes.id < ?", minID).
+				Where("notes.event_created_at < ?", minTS).
 				Limit(1).Count(&count)
 			p.HasNext = count > 0
 		}
@@ -708,7 +679,7 @@ func (st *Storage) GetNotifications(ctx context.Context, p *Pagination) (*[]Even
 			var count int64
 			st.session().Model(&Note{}).
 				Joins("JOIN notifications ON (notifications.note_id = notes.id)").
-				Where("notes.id > ?", maxID).
+				Where("notes.event_created_at > ?", maxTS).
 				Limit(1).Count(&count)
 			p.HasPrev = count > 0
 		}

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -579,23 +579,32 @@ func (st *Storage) GetNotes(ctx context.Context, context string, p *Pagination, 
 		return rows[i].ID > rows[j].ID
 	})
 
-	if (state == stateName[StateInit] || state == stateName[StateNext] || state == stateName[StateRefresh]) && !(len(rows) < int(p.PerPage)) {
-		cursor := rows[0]
-		p.Cursor = cursor.ID
-	}
+	if len(rows) > 0 {
+		maxID := rows[0].ID
+		minID := rows[len(rows)-1].ID
+		p.Cursor = minID
 
-	if (state == stateName[StatePrev] || state == stateName[StateRefresh]) && !(len(rows) < int(p.PerPage)) {
-		cursor := rows[0]
-		p.Cursor = cursor.ID
-	}
+		// A partial page means no more results exist in the direction we were paginating —
+		// no query needed for that side. The opposite direction still requires a check.
+		partialPage := len(rows) < int(p.GetPerPage())
 
-	if state == stateName[StateInit] || state == stateName[StateNext] || state == stateName[StateRefresh] {
-		cursor := rows[len(rows)-1]
-		p.Cursor = cursor.ID
-	}
-	if (state == stateName[StatePrev] || state == stateName[StateRefresh]) && !(len(rows) < int(p.PerPage)) {
-		cursor := rows[len(rows)-1]
-		p.Cursor = cursor.ID
+		if !partialPage || state == stateName[StatePrev] {
+			var count int64
+			st.session().Model(&NotesAndProfiles{}).
+				Where("followed = ? AND bookmarked = ?", options.Follow, options.BookMark).
+				Where("id > ?", maxID).
+				Limit(1).Count(&count)
+			p.HasNext = count > 0
+		}
+
+		if !partialPage || state != stateName[StatePrev] {
+			var count int64
+			st.session().Model(&NotesAndProfiles{}).
+				Where("followed = ? AND bookmarked = ?", options.Follow, options.BookMark).
+				Where("id < ?", minID).
+				Limit(1).Count(&count)
+			p.HasPrev = count > 0
+		}
 	}
 
 	sort.Slice(rows, func(i, j int) bool {
@@ -675,6 +684,34 @@ func (st *Storage) GetNotifications(ctx context.Context, p *Pagination) (*[]Even
 	}
 	if state != stateName[StateInit] {
 		p.Cursor = uint64(notes[0].ID)
+	}
+
+	if len(notes) > 0 {
+		maxID := uint64(notes[0].ID)
+		minID := uint64(notes[len(notes)-1].ID)
+
+		// GetNotifications queries in DESC order: "next" goes to lower IDs (older),
+		// "prev" goes to higher IDs (newer). A partial page means no more exist
+		// in the direction we were paginating.
+		partialPage := len(notes) < perPage
+
+		if !partialPage || state == stateName[StatePrev] {
+			var count int64
+			st.session().Model(&Note{}).
+				Joins("JOIN notifications ON (notifications.note_id = notes.id)").
+				Where("notes.id < ?", minID).
+				Limit(1).Count(&count)
+			p.HasNext = count > 0
+		}
+
+		if !partialPage || state != stateName[StatePrev] {
+			var count int64
+			st.session().Model(&Note{}).
+				Joins("JOIN notifications ON (notifications.note_id = notes.id)").
+				Where("notes.id > ?", maxID).
+				Limit(1).Count(&count)
+			p.HasPrev = count > 0
+		}
 	}
 
 	var root_tags []string

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -542,10 +542,10 @@ func (st *Storage) GetNotes(ctx context.Context, context string, p *Pagination, 
 	if p.Cursor > 0 {
 		state = stateName[StateRefresh]
 	}
-	if p.NextCursor != 0 {
+	if p.Direction == "next" {
 		state = stateName[StateNext]
 	}
-	if p.PreviousCursor != 0 {
+	if p.Direction == "prev" {
 		state = stateName[StatePrev]
 	}
 	st.initPaging(p, options)
@@ -559,11 +559,11 @@ func (st *Storage) GetNotes(ctx context.Context, context string, p *Pagination, 
 	}
 
 	if state == stateName[StateNext] {
-		tx = tx.Where("id > ?", p.NextCursor).
+		tx = tx.Where("id > ?", p.Cursor).
 			Order("id ASC")
 	}
 	if state == stateName[StatePrev] {
-		tx = tx.Where("id < ?", p.PreviousCursor).
+		tx = tx.Where("id < ?", p.Cursor).
 			Order("id DESC")
 	}
 
@@ -575,30 +575,27 @@ func (st *Storage) GetNotes(ctx context.Context, context string, p *Pagination, 
 		return &[]Event{}, nil
 	}
 
-	p.NextCursor = 0
-	p.PreviousCursor = 0
-
 	sort.Slice(rows, func(i, j int) bool {
 		return rows[i].ID > rows[j].ID
 	})
 
 	if (state == stateName[StateInit] || state == stateName[StateNext] || state == stateName[StateRefresh]) && !(len(rows) < int(p.PerPage)) {
-		next_cursor := rows[0]
-		p.NextCursor = next_cursor.ID
+		cursor := rows[0]
+		p.Cursor = cursor.ID
 	}
 
 	if (state == stateName[StatePrev] || state == stateName[StateRefresh]) && !(len(rows) < int(p.PerPage)) {
-		next_cursor := rows[0]
-		p.NextCursor = next_cursor.ID
+		cursor := rows[0]
+		p.Cursor = cursor.ID
 	}
 
 	if state == stateName[StateInit] || state == stateName[StateNext] || state == stateName[StateRefresh] {
-		prev_cursor := rows[len(rows)-1]
-		p.PreviousCursor = prev_cursor.ID
+		cursor := rows[len(rows)-1]
+		p.Cursor = cursor.ID
 	}
 	if (state == stateName[StatePrev] || state == stateName[StateRefresh]) && !(len(rows) < int(p.PerPage)) {
-		prev_cursor := rows[len(rows)-1]
-		p.PreviousCursor = prev_cursor.ID
+		cursor := rows[len(rows)-1]
+		p.Cursor = cursor.ID
 	}
 
 	sort.Slice(rows, func(i, j int) bool {
@@ -641,10 +638,10 @@ func (st *Storage) GetNotifications(ctx context.Context, p *Pagination) (*[]Even
 	if p.Cursor > 0 {
 		state = stateName[StateRefresh]
 	}
-	if p.NextCursor != 0 {
+	if p.Direction == "next" {
 		state = stateName[StateNext]
 	}
-	if p.PreviousCursor != 0 {
+	if p.Direction == "prev" {
 		state = stateName[StatePrev]
 	}
 	slog.Info("State is: ", "state", state)
@@ -655,9 +652,9 @@ func (st *Storage) GetNotifications(ctx context.Context, p *Pagination) (*[]Even
 	// Apply the cursor to the driving query so pagination actually advances.
 	switch state {
 	case stateName[StateNext]:
-		tx = tx.Where("notes.id < ?", p.NextCursor)
+		tx = tx.Where("notes.id < ?", p.Cursor)
 	case stateName[StatePrev]:
-		tx = tx.Where("notes.id > ?", p.PreviousCursor)
+		tx = tx.Where("notes.id > ?", p.Cursor)
 	case stateName[StateRefresh]:
 		tx = tx.Where("notes.id > ?", p.Cursor)
 	}
@@ -672,13 +669,12 @@ func (st *Storage) GetNotifications(ctx context.Context, p *Pagination) (*[]Even
 	// Cursors track the notification notes themselves (ordered by id DESC):
 	// the last (oldest) id pages forward, the first (newest) id pages back.
 	perPage := int(p.GetPerPage())
-	p.NextCursor = 0
-	p.PreviousCursor = 0
+
 	if len(notes) >= perPage {
-		p.NextCursor = uint64(notes[len(notes)-1].ID)
+		p.Cursor = uint64(notes[len(notes)-1].ID)
 	}
 	if state != stateName[StateInit] {
-		p.PreviousCursor = uint64(notes[0].ID)
+		p.Cursor = uint64(notes[0].ID)
 	}
 
 	var root_tags []string

--- a/internal/http/controllers.go
+++ b/internal/http/controllers.go
@@ -58,13 +58,12 @@ var syncHash string = ""
 
 // Send from client API
 type PageRequest struct {
-	Cursor     uint64 `json:"cursor"`
-	PrevCursor uint64 `json:"prev_cursor"`
-	NextCursor uint64 `json:"next_cursor"`
-	PerPage    uint   `json:"per_page"`
-	Since      uint   `json:"since"`
-	Renew      bool   `json:"renew"`
-	Context    string `json:"context"`
+	Cursor    uint64 `json:"cursor"`
+	Direction string `json:"direction"`
+	PerPage   uint   `json:"per_page"`
+	Since     uint   `json:"since"`
+	Renew     bool   `json:"renew"`
+	Context   string `json:"context"`
 }
 
 // Response godoc
@@ -98,11 +97,8 @@ func (c *Controller) parseUrlParams(r *http.Request) PageRequest {
 	cursor := r.URL.Query().Get("cursor")
 	p.Cursor, _ = strconv.ParseUint(cursor, 10, 64)
 
-	next_cursor := r.URL.Query().Get("next_cursor")
-	p.NextCursor, _ = strconv.ParseUint(next_cursor, 10, 64)
-
-	prev_cursor := r.URL.Query().Get("prev_cursor")
-	p.PrevCursor, _ = strconv.ParseUint(prev_cursor, 10, 64)
+	direction := r.URL.Query().Get("direction")
+	p.Direction = direction
 
 	per_page := r.URL.Query().Get("per_page")
 	perpage, _ := strconv.ParseUint(per_page, 10, 64)
@@ -153,10 +149,8 @@ func (c *Controller) GetNotes() http.HandlerFunc {
 		p := c.parseUrlParams(r)
 
 		pagination := db.Pagination{}
-		pagination.SetPerPage(uint(p.PerPage))
 		pagination.SetCursor(p.Cursor)
-		pagination.SetPrev(p.PrevCursor)
-		pagination.SetNext(p.NextCursor)
+		pagination.SetDirection(p.Direction)
 		pagination.SetPerPage(p.PerPage)
 		pagination.SetSince(p.Since)
 
@@ -189,10 +183,8 @@ func (c *Controller) GetNotes() http.HandlerFunc {
 		if len(*data.Events) == 0 {
 			response.Status = "empty"
 			response.Message = "No results"
-			pagination.SetPerPage(uint(p.PerPage))
 			pagination.SetCursor(p.Cursor)
-			pagination.SetPrev(p.PrevCursor)
-			pagination.SetNext(0)
+			pagination.SetDirection(p.Direction)
 			pagination.SetPerPage(p.PerPage)
 			pagination.SetSince(p.Since)
 			data.Paging = &pagination
@@ -229,10 +221,8 @@ func (c *Controller) GetInbox() http.HandlerFunc {
 		p := c.parseUrlParams(r)
 
 		pagination := db.Pagination{}
-		pagination.SetPerPage(uint(p.PerPage))
 		pagination.SetCursor(p.Cursor)
-		pagination.SetPrev(p.PrevCursor)
-		pagination.SetNext(p.NextCursor)
+		pagination.SetDirection(p.Direction)
 		pagination.SetPerPage(p.PerPage)
 		pagination.SetSince(p.Since)
 
@@ -260,10 +250,8 @@ func (c *Controller) GetNotifications() http.HandlerFunc {
 		p := c.parseUrlParams(r)
 
 		pagination := db.Pagination{}
-		pagination.SetPerPage(uint(p.PerPage))
 		pagination.SetCursor(p.Cursor)
-		pagination.SetPrev(p.PrevCursor)
-		pagination.SetNext(p.NextCursor)
+		pagination.SetDirection(p.Direction)
 		pagination.SetPerPage(p.PerPage)
 		pagination.SetSince(p.Since)
 
@@ -656,7 +644,7 @@ func (c *Controller) RemoveBookMark() http.HandlerFunc {
 // @Tags         relay
 // @Accept       json
 // @Produce      json
-// @Param        Body body Relay true "Body for the retrieval of data"
+// @Param        Body body db.Relay true "Body for the retrieval of data"
 // @Success      200  {object}  Response
 // @Failure      400  {string}  string    "error"
 // @Failure      404  {string}  string    "error"
@@ -707,7 +695,7 @@ func (c *Controller) AddRelay() http.HandlerFunc {
 // @Tags         relay
 // @Accept       json
 // @Produce      json
-// @Param        Body body Relay true "Body for the retrieval of data"
+// @Param        Body body db.Relay true "Body for the retrieval of data"
 // @Success      200  {object}  Response
 // @Failure      400  {string}  string    "error"
 // @Failure      404  {string}  string    "error"
@@ -810,8 +798,6 @@ func (c *Controller) GetNewNotesCount() http.HandlerFunc {
 
 		var err error
 		var p PageRequest
-		cursor := r.URL.Query().Get("cursor")
-		p.Cursor, _ = strconv.ParseUint(cursor, 10, 64)
 
 		renew := r.URL.Query().Get("renew")
 		p.Renew, _ = strconv.ParseBool(renew)
@@ -1128,7 +1114,7 @@ func (c *Controller) GetMetaData() http.HandlerFunc {
 // @Tags         profile
 // @Accept       json
 // @Produce      json
-// @Param        Body body Profile true "Body for the retrieval of data"
+// @Param        Body body db.Profile true "Body for the retrieval of data"
 // @Success      200  {object}  Response
 // @Failure      400  {string}  string    "error"
 // @Failure      404  {string}  string    "error"


### PR DESCRIPTION
## Summary

- Replaces `next_cursor`/`prev_cursor` with a single `cursor` + `direction` model
- Fixes Swagger annotations (`db.Relay`, `db.Profile`) and adds `swaggertype` tags for `NullString` and `pq.StringArray` fields so `swag init` runs cleanly
- Removes dead `GetPage()` method and duplicate `SetPerPage` calls in all three controllers
- Adds `has_next` and `has_prev` booleans to the `Pagination` response so the frontend can enable/disable prev/next buttons without guessing
- Switches the pagination cursor from database ingestion `id` to `event_created_at` (Unix timestamp), fixing a bug where prev/next jumped to unrelated time periods because ingestion order and event timestamps diverged

## Why event_created_at?

Notes are stored in ingestion order (auto-increment `id`), but displayed by `event_created_at`. Paginating by `id` while displaying by timestamp caused prev to skip large time gaps. Cursoring on `event_created_at` ensures each page boundary aligns with what the user actually sees.

## Cursor contract (frontend)

- `cursor` in the response = oldest `event_created_at` on the current page → use for `direction=prev`
- For `direction=next`, use the newest `event_created_at` from the events array
- `has_next` / `has_prev` indicate whether the respective button should be enabled

## Test plan

- [x] Initial load returns the most recent notes
- [x] `direction=next` returns notes newer than the provided timestamp with no overlap
- [x] `direction=prev` returns notes older than the provided timestamp with no overlap
- [x] `has_next` is `false` on the newest page, `has_prev` is `false` on the oldest page
- [x] Swagger UI shows correct schema for `PageRequest`, `db.Relay`, and `db.Profile`

Closes #37