### PR TITLE
docs: fix all Swagger annotations in controllers.go

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -510,24 +510,19 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "integer",
-                        "description": "Cursor",
+                        "description": "Unix timestamp cursor (event_created_at); 0 loads the latest page",
                         "name": "cursor",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     },
                     {
-                        "type": "integer",
-                        "description": "Start id",
-                        "name": "start_id",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "End id",
-                        "name": "end_id",
-                        "in": "query",
-                        "required": true
+                        "enum": [
+                            "next",
+                            "prev"
+                        ],
+                        "type": "string",
+                        "description": "Pagination direction",
+                        "name": "direction",
+                        "in": "query"
                     },
                     {
                         "type": "integer",
@@ -539,13 +534,13 @@ const docTemplate = `{
                     {
                         "type": "boolean",
                         "default": false,
-                        "description": "Renew page and ignore start_id",
+                        "description": "Force refresh ignoring cache",
                         "name": "renew",
                         "in": "query"
                     },
                     {
                         "type": "integer",
-                        "description": "Since",
+                        "description": "Since timestamp",
                         "name": "since",
                         "in": "query"
                     },
@@ -557,7 +552,7 @@ const docTemplate = `{
                             "global"
                         ],
                         "type": "string",
-                        "description": "string enum",
+                        "description": "Feed context",
                         "name": "context",
                         "in": "query"
                     }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -266,7 +266,7 @@ const docTemplate = `{
         },
         "/api/getinbox": {
             "get": {
-                "description": "get Notes that you responded to",
+                "description": "Returns notes from threads the authenticated user has participated in",
                 "consumes": [
                     "application/json"
                 ],
@@ -276,16 +276,36 @@ const docTemplate = `{
                 "tags": [
                     "notes"
                 ],
-                "summary": "Retrieve stored Notes",
+                "summary": "Retrieve inbox notes",
                 "parameters": [
                     {
-                        "description": "Body for the retrieval of data",
-                        "name": "Body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/http.PageRequest"
-                        }
+                        "type": "integer",
+                        "description": "Unix timestamp cursor (event_created_at); 0 loads the latest page",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "next",
+                            "prev"
+                        ],
+                        "type": "string",
+                        "description": "Pagination direction",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Results per page",
+                        "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Since timestamp",
+                        "name": "since",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -359,7 +379,7 @@ const docTemplate = `{
         },
         "/api/getmetadata": {
             "get": {
-                "description": "Set your profile data",
+                "description": "Fetches the authenticated user's profile metadata from relays",
                 "consumes": [
                     "application/json"
                 ],
@@ -369,7 +389,7 @@ const docTemplate = `{
                 "tags": [
                     "profile"
                 ],
-                "summary": "Set your profile data",
+                "summary": "Get your profile data",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -400,7 +420,7 @@ const docTemplate = `{
         },
         "/api/getnewnotescount": {
             "get": {
-                "description": "Get count of new notes",
+                "description": "Returns the number of notes newer than the last seen note id",
                 "consumes": [
                     "application/json"
                 ],
@@ -413,47 +433,6 @@ const docTemplate = `{
                 "summary": "Get count of new notes",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "Cursor",
-                        "name": "cursor",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Start id",
-                        "name": "start_id",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "End id",
-                        "name": "end_id",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "default": 10,
-                        "description": "Results per page",
-                        "name": "per_page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Renew page and ignore start_id",
-                        "name": "renew",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Since",
-                        "name": "since",
-                        "in": "query"
-                    },
-                    {
                         "enum": [
                             "follow",
                             "bookmark",
@@ -461,7 +440,7 @@ const docTemplate = `{
                             "global"
                         ],
                         "type": "string",
-                        "description": "string enum",
+                        "description": "Feed context",
                         "name": "context",
                         "in": "query"
                     }
@@ -585,6 +564,72 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/getnotifications": {
+            "get": {
+                "description": "Returns notes that mention or reply to the authenticated user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notes"
+                ],
+                "summary": "Retrieve notifications",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Unix timestamp cursor (event_created_at); 0 loads the latest page",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "next",
+                            "prev"
+                        ],
+                        "type": "string",
+                        "description": "Pagination direction",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Results per page",
+                        "name": "per_page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/http.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/getprofile": {
             "get": {
                 "description": "Get your profile data",
@@ -669,7 +714,7 @@ const docTemplate = `{
         },
         "/api/publish": {
             "post": {
-                "description": "Get count of new notes",
+                "description": "Publishes a new note or a reply to an existing note and broadcasts it to relays",
                 "consumes": [
                     "application/json"
                 ],
@@ -679,7 +724,7 @@ const docTemplate = `{
                 "tags": [
                     "publish"
                 ],
-                "summary": "Get count of new notes",
+                "summary": "Publish a note or reply",
                 "parameters": [
                     {
                         "description": "Body for the retrieval of data",
@@ -1048,29 +1093,6 @@ const docTemplate = `{
                 },
                 "msg": {
                     "type": "string"
-                }
-            }
-        },
-        "http.PageRequest": {
-            "type": "object",
-            "properties": {
-                "context": {
-                    "type": "string"
-                },
-                "cursor": {
-                    "type": "integer"
-                },
-                "direction": {
-                    "type": "string"
-                },
-                "per_page": {
-                    "type": "integer"
-                },
-                "renew": {
-                    "type": "boolean"
-                },
-                "since": {
-                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -255,7 +255,7 @@
         },
         "/api/getinbox": {
             "get": {
-                "description": "get Notes that you responded to",
+                "description": "Returns notes from threads the authenticated user has participated in",
                 "consumes": [
                     "application/json"
                 ],
@@ -265,16 +265,36 @@
                 "tags": [
                     "notes"
                 ],
-                "summary": "Retrieve stored Notes",
+                "summary": "Retrieve inbox notes",
                 "parameters": [
                     {
-                        "description": "Body for the retrieval of data",
-                        "name": "Body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/http.PageRequest"
-                        }
+                        "type": "integer",
+                        "description": "Unix timestamp cursor (event_created_at); 0 loads the latest page",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "next",
+                            "prev"
+                        ],
+                        "type": "string",
+                        "description": "Pagination direction",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Results per page",
+                        "name": "per_page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Since timestamp",
+                        "name": "since",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -348,7 +368,7 @@
         },
         "/api/getmetadata": {
             "get": {
-                "description": "Set your profile data",
+                "description": "Fetches the authenticated user's profile metadata from relays",
                 "consumes": [
                     "application/json"
                 ],
@@ -358,7 +378,7 @@
                 "tags": [
                     "profile"
                 ],
-                "summary": "Set your profile data",
+                "summary": "Get your profile data",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -389,7 +409,7 @@
         },
         "/api/getnewnotescount": {
             "get": {
-                "description": "Get count of new notes",
+                "description": "Returns the number of notes newer than the last seen note id",
                 "consumes": [
                     "application/json"
                 ],
@@ -402,47 +422,6 @@
                 "summary": "Get count of new notes",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "Cursor",
-                        "name": "cursor",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Start id",
-                        "name": "start_id",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "End id",
-                        "name": "end_id",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "default": 10,
-                        "description": "Results per page",
-                        "name": "per_page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Renew page and ignore start_id",
-                        "name": "renew",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Since",
-                        "name": "since",
-                        "in": "query"
-                    },
-                    {
                         "enum": [
                             "follow",
                             "bookmark",
@@ -450,7 +429,7 @@
                             "global"
                         ],
                         "type": "string",
-                        "description": "string enum",
+                        "description": "Feed context",
                         "name": "context",
                         "in": "query"
                     }
@@ -574,6 +553,72 @@
                 }
             }
         },
+        "/api/getnotifications": {
+            "get": {
+                "description": "Returns notes that mention or reply to the authenticated user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notes"
+                ],
+                "summary": "Retrieve notifications",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Unix timestamp cursor (event_created_at); 0 loads the latest page",
+                        "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "next",
+                            "prev"
+                        ],
+                        "type": "string",
+                        "description": "Pagination direction",
+                        "name": "direction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Results per page",
+                        "name": "per_page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/http.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/getprofile": {
             "get": {
                 "description": "Get your profile data",
@@ -658,7 +703,7 @@
         },
         "/api/publish": {
             "post": {
-                "description": "Get count of new notes",
+                "description": "Publishes a new note or a reply to an existing note and broadcasts it to relays",
                 "consumes": [
                     "application/json"
                 ],
@@ -668,7 +713,7 @@
                 "tags": [
                     "publish"
                 ],
-                "summary": "Get count of new notes",
+                "summary": "Publish a note or reply",
                 "parameters": [
                     {
                         "description": "Body for the retrieval of data",
@@ -1037,29 +1082,6 @@
                 },
                 "msg": {
                     "type": "string"
-                }
-            }
-        },
-        "http.PageRequest": {
-            "type": "object",
-            "properties": {
-                "context": {
-                    "type": "string"
-                },
-                "cursor": {
-                    "type": "integer"
-                },
-                "direction": {
-                    "type": "string"
-                },
-                "per_page": {
-                    "type": "integer"
-                },
-                "renew": {
-                    "type": "boolean"
-                },
-                "since": {
-                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -499,24 +499,19 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "description": "Cursor",
+                        "description": "Unix timestamp cursor (event_created_at); 0 loads the latest page",
                         "name": "cursor",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     },
                     {
-                        "type": "integer",
-                        "description": "Start id",
-                        "name": "start_id",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "End id",
-                        "name": "end_id",
-                        "in": "query",
-                        "required": true
+                        "enum": [
+                            "next",
+                            "prev"
+                        ],
+                        "type": "string",
+                        "description": "Pagination direction",
+                        "name": "direction",
+                        "in": "query"
                     },
                     {
                         "type": "integer",
@@ -528,13 +523,13 @@
                     {
                         "type": "boolean",
                         "default": false,
-                        "description": "Renew page and ignore start_id",
+                        "description": "Force refresh ignoring cache",
                         "name": "renew",
                         "in": "query"
                     },
                     {
                         "type": "integer",
-                        "description": "Since",
+                        "description": "Since timestamp",
                         "name": "since",
                         "in": "query"
                     },
@@ -546,7 +541,7 @@
                             "global"
                         ],
                         "type": "string",
-                        "description": "string enum",
+                        "description": "Feed context",
                         "name": "context",
                         "in": "query"
                     }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -409,36 +409,33 @@ paths:
       - application/json
       description: get Notes
       parameters:
-      - description: Cursor
+      - description: Unix timestamp cursor (event_created_at); 0 loads the latest
+          page
         in: query
         name: cursor
-        required: true
         type: integer
-      - description: Start id
+      - description: Pagination direction
+        enum:
+        - next
+        - prev
         in: query
-        name: start_id
-        required: true
-        type: integer
-      - description: End id
-        in: query
-        name: end_id
-        required: true
-        type: integer
+        name: direction
+        type: string
       - default: 10
         description: Results per page
         in: query
         name: per_page
         type: integer
       - default: false
-        description: Renew page and ignore start_id
+        description: Force refresh ignoring cache
         in: query
         name: renew
         type: boolean
-      - description: Since
+      - description: Since timestamp
         in: query
         name: since
         type: integer
-      - description: string enum
+      - description: Feed context
         enum:
         - follow
         - bookmark

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -52,21 +52,6 @@ definitions:
       msg:
         type: string
     type: object
-  http.PageRequest:
-    properties:
-      context:
-        type: string
-      cursor:
-        type: integer
-      direction:
-        type: string
-      per_page:
-        type: integer
-      renew:
-        type: boolean
-      since:
-        type: integer
-    type: object
   http.Pubkey:
     properties:
       pubkey:
@@ -253,14 +238,30 @@ paths:
     get:
       consumes:
       - application/json
-      description: get Notes that you responded to
+      description: Returns notes from threads the authenticated user has participated
+        in
       parameters:
-      - description: Body for the retrieval of data
-        in: body
-        name: Body
-        required: true
-        schema:
-          $ref: '#/definitions/http.PageRequest'
+      - description: Unix timestamp cursor (event_created_at); 0 loads the latest
+          page
+        in: query
+        name: cursor
+        type: integer
+      - description: Pagination direction
+        enum:
+        - next
+        - prev
+        in: query
+        name: direction
+        type: string
+      - default: 10
+        description: Results per page
+        in: query
+        name: per_page
+        type: integer
+      - description: Since timestamp
+        in: query
+        name: since
+        type: integer
       produces:
       - application/json
       responses:
@@ -280,7 +281,7 @@ paths:
           description: error
           schema:
             type: string
-      summary: Retrieve stored Notes
+      summary: Retrieve inbox notes
       tags:
       - notes
   /api/getlastseenid:
@@ -314,7 +315,7 @@ paths:
     get:
       consumes:
       - application/json
-      description: Set your profile data
+      description: Fetches the authenticated user's profile metadata from relays
       produces:
       - application/json
       responses:
@@ -334,45 +335,16 @@ paths:
           description: error
           schema:
             type: string
-      summary: Set your profile data
+      summary: Get your profile data
       tags:
       - profile
   /api/getnewnotescount:
     get:
       consumes:
       - application/json
-      description: Get count of new notes
+      description: Returns the number of notes newer than the last seen note id
       parameters:
-      - description: Cursor
-        in: query
-        name: cursor
-        required: true
-        type: integer
-      - description: Start id
-        in: query
-        name: start_id
-        required: true
-        type: integer
-      - description: End id
-        in: query
-        name: end_id
-        required: true
-        type: integer
-      - default: 10
-        description: Results per page
-        in: query
-        name: per_page
-        type: integer
-      - default: false
-        description: Renew page and ignore start_id
-        in: query
-        name: renew
-        type: boolean
-      - description: Since
-        in: query
-        name: since
-        type: integer
-      - description: string enum
+      - description: Feed context
         enum:
         - follow
         - bookmark
@@ -466,6 +438,51 @@ paths:
       summary: Retrieve stored Notes
       tags:
       - notes
+  /api/getnotifications:
+    get:
+      consumes:
+      - application/json
+      description: Returns notes that mention or reply to the authenticated user
+      parameters:
+      - description: Unix timestamp cursor (event_created_at); 0 loads the latest
+          page
+        in: query
+        name: cursor
+        type: integer
+      - description: Pagination direction
+        enum:
+        - next
+        - prev
+        in: query
+        name: direction
+        type: string
+      - default: 10
+        description: Results per page
+        in: query
+        name: per_page
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/http.Response'
+        "400":
+          description: error
+          schema:
+            type: string
+        "404":
+          description: error
+          schema:
+            type: string
+        "500":
+          description: error
+          schema:
+            type: string
+      summary: Retrieve notifications
+      tags:
+      - notes
   /api/getprofile:
     get:
       consumes:
@@ -524,7 +541,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: Get count of new notes
+      description: Publishes a new note or a reply to an existing note and broadcasts
+        it to relays
       parameters:
       - description: Body for the retrieval of data
         in: body
@@ -551,7 +569,7 @@ paths:
           description: error
           schema:
             type: string
-      summary: Get count of new notes
+      summary: Publish a note or reply
       tags:
       - publish
   /api/removebookmark:

--- a/internal/http/controllers.go
+++ b/internal/http/controllers.go
@@ -200,12 +200,15 @@ func (c *Controller) GetNotes() http.HandlerFunc {
 }
 
 // GetInbox godoc
-// @Summary      Retrieve stored Notes
-// @Description  get Notes that you responded to
+// @Summary      Retrieve inbox notes
+// @Description  Returns notes from threads the authenticated user has participated in
 // @Tags         notes
 // @Accept       json
 // @Produce      json
-// @Param        Body body PageRequest true "Body for the retrieval of data"
+// @Param		cursor		query	int		false	"Unix timestamp cursor (event_created_at); 0 loads the latest page"
+// @Param		direction	query	string	false	"Pagination direction" Enums(next,prev)
+// @Param		per_page	query	int		false	"Results per page" Default(10)
+// @Param		since		query	int		false	"Since timestamp"
 // @Success      200  {object}  Response
 // @Failure      400  {string}  string    "error"
 // @Failure      404  {string}  string    "error"
@@ -240,6 +243,20 @@ func (c *Controller) GetInbox() http.HandlerFunc {
 	}
 }
 
+// GetNotifications godoc
+// @Summary      Retrieve notifications
+// @Description  Returns notes that mention or reply to the authenticated user
+// @Tags         notes
+// @Accept       json
+// @Produce      json
+// @Param		cursor		query	int		false	"Unix timestamp cursor (event_created_at); 0 loads the latest page"
+// @Param		direction	query	string	false	"Pagination direction" Enums(next,prev)
+// @Param		per_page	query	int		false	"Results per page" Default(10)
+// @Success      200  {object}  Response
+// @Failure      400  {string}  string    "error"
+// @Failure      404  {string}  string    "error"
+// @Failure      500  {string}  string    "error"
+// @Router       /api/getnotifications [get]
 func (c *Controller) GetNotifications() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
@@ -773,17 +790,11 @@ func (c *Controller) GetRelays() http.HandlerFunc {
 
 // GetNewNotesCount godoc
 // @Summary      Get count of new notes
-// @Description  Get count of new notes
+// @Description  Returns the number of notes newer than the last seen note id
 // @Tags         notes
 // @Accept       json
 // @Produce      json
-// @Param		 cursor	query	int	true	"Cursor"
-// @Param		 start_id	query	int	true	"Start id"
-// @Param		 end_id		query	int	true	"End id"
-// @Param		 per_page	query	int	false	"Results per page"	Default(10)
-// @Param		 renew		query	bool	false	"Renew page and ignore start_id" Default(false)
-// @Param		 since		query	int	false	"Since"
-// @Param		context	query string false "string enum" Enums(follow, bookmark, refresh, global)
+// @Param		context	query	string	false	"Feed context" Enums(follow,bookmark,refresh,global)
 // @Success      200  {object}  Response
 // @Failure      400  {string}  string    "error"
 // @Failure      404  {string}  string    "error"
@@ -971,8 +982,8 @@ func (c *Controller) PreviewLink() http.HandlerFunc {
 }
 
 // Publish godoc
-// @Summary      Get count of new notes
-// @Description  Get count of new notes
+// @Summary      Publish a note or reply
+// @Description  Publishes a new note or a reply to an existing note and broadcasts it to relays
 // @Tags         publish
 // @Accept       json
 // @Produce      json
@@ -1064,9 +1075,9 @@ func (c *Controller) Publish() http.HandlerFunc {
 
 }
 
-// SetMetaData godoc
-// @Summary      Set your profile data
-// @Description  Set your profile data
+// GetMetaData godoc
+// @Summary      Get your profile data
+// @Description  Fetches the authenticated user's profile metadata from relays
 // @Tags         profile
 // @Accept       json
 // @Produce      json

--- a/internal/http/controllers.go
+++ b/internal/http/controllers.go
@@ -128,13 +128,12 @@ func (c *Controller) parseUrlParams(r *http.Request) PageRequest {
 // @Tags         notes
 // @Accept       json
 // @Produce      json
-// @Param		 cursor	query	int	true	"Cursor"
-// @Param		 start_id	query	int	true	"Start id"
-// @Param		 end_id		query	int	true	"End id"
-// @Param		 per_page	query	int	false	"Results per page"	Default(10)
-// @Param		 renew		query	bool	false	"Renew page and ignore start_id" Default(false)
-// @Param		 since		query	int	false	"Since"
-// @Param		context	query string false "string enum" Enums(follow, bookmark, refresh, global)
+// @Param		cursor		query	int		false	"Unix timestamp cursor (event_created_at); 0 loads the latest page"
+// @Param		direction	query	string	false	"Pagination direction" Enums(next,prev)
+// @Param		per_page	query	int		false	"Results per page" Default(10)
+// @Param		renew		query	bool	false	"Force refresh ignoring cache" Default(false)
+// @Param		since		query	int		false	"Since timestamp"
+// @Param		context		query	string	false	"Feed context" Enums(follow,bookmark,refresh,global)
 // @Success      200  {object}  Response
 // @Failure      400  {string}  string    "error"
 // @Failure      404  {string}  string    "error"


### PR DESCRIPTION
## Summary

Fixes stale and incorrect Swagger annotations that were left behind after the pagination refactor.

- **GetNotes**: `cursor` marked optional (was required), `direction` added with `Enums(next,prev)`, stale `start_id` reference removed from `renew` description
- **GetNewNotesCount**: remove `start_id`, `end_id`, `cursor`, `per_page` params — the function only reads `context`; the count is derived from the last seen id internally
- **GetInbox**: replace `body PageRequest` with correct query params — function uses `parseUrlParams`, not a request body
- **GetNotifications**: add missing Swagger annotation entirely
- **Publish**: fix summary/description (was copy-pasted from GetNewNotesCount)
- **GetMetaData**: fix godoc name (was `SetMetaData`) and summary (was "Set your profile data")

Swagger docs regenerated via `swag init`.

## Test plan

- [x] `swag init` runs without errors
- [x] Swagger UI shows correct params for `/api/getnotes`, `/api/getinbox`, `/api/getnotifications`, `/api/getnewnotescount`
- [x] `/api/publish` and `/api/getmetadata` show correct summary and description