### PR TITLE
feat: replace seens table with event_created_at watermark (#40)

### DIFF
--- a/internal/db/entities.go
+++ b/internal/db/entities.go
@@ -153,15 +153,13 @@ func (entity *Follow) BeforeUpdate(tx *gorm.DB) error {
 	return nil
 }
 
-type Seen struct {
-	ID        uint      `gorm:"primaryKey" json:"-"`
-	EventId   string    `gorm:"type:varchar(100);index,type:btree;not null;unique;" json:"event_id"`
-	NoteID    uint      `gorm:"type:bigint;index,type:btree;not null;unique;" json:"-"`
-	CreatedAt time.Time `gorm:"type:timestamp;default:current_timestamp" json:"-"`
-	UpdatedAt time.Time `gorm:"type:timestamp;default:null" json:"-"`
+type Watermark struct {
+	Context        string    `gorm:"primaryKey;type:varchar(20)" json:"context"`
+	EventCreatedAt int64     `gorm:"type:bigint;not null;default:0" json:"event_created_at"`
+	UpdatedAt      time.Time `gorm:"type:TIMESTAMPTZ;default:current_timestamp" json:"-"`
 }
 
-func (entity *Seen) BeforeUpdate(tx *gorm.DB) error {
+func (entity *Watermark) BeforeUpdate(tx *gorm.DB) error {
 	entity.UpdatedAt = time.Now()
 	return nil
 }

--- a/internal/db/migrations/000007_create_watermarks_table.down.sql
+++ b/internal/db/migrations/000007_create_watermarks_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.watermarks;

--- a/internal/db/migrations/000007_create_watermarks_table.up.sql
+++ b/internal/db/migrations/000007_create_watermarks_table.up.sql
@@ -1,0 +1,5 @@
+CREATE TABLE public.watermarks (
+    context         VARCHAR(20) PRIMARY KEY,
+    event_created_at BIGINT NOT NULL DEFAULT 0,
+    updated_at      TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);

--- a/internal/db/storage.go
+++ b/internal/db/storage.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"log/slog"
@@ -446,29 +447,56 @@ type Options struct {
 	Renew    bool
 }
 
-func (st *Storage) GetNewNotesCount(ctx context.Context, cursor uint64, options Options) (int, error) {
+func (st *Storage) GetCaughtUpAt(ctx context.Context, feedContext string) (int64, error) {
+	var watermark Watermark
+	result := st.GormDB.WithContext(ctx).Where("context = ?", feedContext).First(&watermark)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return time.Now().Add(-24 * time.Hour).Unix(), nil
+		}
+		return 0, result.Error
+	}
+	if watermark.EventCreatedAt == 0 {
+		return time.Now().Add(-24 * time.Hour).Unix(), nil
+	}
+	return watermark.EventCreatedAt, nil
+}
+
+func (st *Storage) SetCaughtUpAt(ctx context.Context, feedContext string, options Options) error {
+	var maxAt int64
+	st.GormDB.WithContext(ctx).Model(&NotesAndProfiles{}).
+		Select("COALESCE(MAX(event_created_at), 0)").
+		Where("followed = ? AND bookmarked = ?", options.Follow, options.BookMark).
+		Scan(&maxAt)
+
+	watermark := Watermark{
+		Context:        feedContext,
+		EventCreatedAt: maxAt,
+		UpdatedAt:      time.Now(),
+	}
+	return st.GormDB.WithContext(ctx).
+		Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "context"}},
+			DoUpdates: clause.AssignmentColumns([]string{"event_created_at", "updated_at"}),
+		}).Create(&watermark).Error
+}
+
+func (st *Storage) GetNewNotesCount(ctx context.Context, feedContext string, options Options) (int, error) {
+	caughtUpAt, err := st.GetCaughtUpAt(ctx, feedContext)
+	if err != nil {
+		return 0, err
+	}
 	var count int
-	tx := st.GormDB.Model(&NotesAndProfiles{}).
+	tx := st.GormDB.WithContext(ctx).Model(&NotesAndProfiles{}).
 		Select(`COUNT(id)`).
-		Where("id > ?", cursor).
-		Where("followed = ? and bookmarked = ?", options.Follow, options.BookMark).
+		Where("event_created_at > ?", caughtUpAt).
+		Where("followed = ? AND bookmarked = ?", options.Follow, options.BookMark).
 		Find(&count)
 
 	if tx.Error != nil {
 		return 0, tx.Error
 	}
 	return count, nil
-}
-
-func (st *Storage) GetLastSeenID(ctx context.Context) (int, error) {
-	var maxId int
-	tx := st.GormDB.Model(&Seen{}).
-		Select(`MAX(coalesce(note_id,0))`).Scan(&maxId)
-
-	if tx.Error != nil {
-		return 0, tx.Error
-	}
-	return maxId, nil
 }
 
 
@@ -588,21 +616,10 @@ func (st *Storage) GetNotes(ctx context.Context, context string, p *Pagination, 
 		}
 	}
 
-	eventMap, keys, seenMap, err := st.procesEventRows(&rows)
+	eventMap, keys, _, err := st.procesEventRows(&rows)
 	if err != nil {
 		slog.Error(logger.GetCallerInfo(1), "error", err.Error())
 		return &[]Event{}, err
-	}
-
-	tx = st.GormDB.WithContext(ctx).Model(&Seen{})
-	seens := []*Seen{}
-	for noteid, eventid := range seenMap {
-		seens = append(seens, &Seen{NoteID: uint(noteid), EventId: eventid})
-	}
-
-	result := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&seens)
-	if result.Error != nil {
-		return &[]Event{}, result.Error
 	}
 
 	st.getChildren(ctx, eventMap)
@@ -1079,12 +1096,11 @@ func (st *Storage) FindEvent(ctx context.Context, id string) (Event, error) {
 	FROM trees t, notes e
 	LEFT JOIN profiles u ON (u.pubkey = e.pubkey )
 	LEFT JOIN blocks b on (b.pubkey = e.pubkey)
-	LEFT JOIN seens s on (s.event_id = e.event_id)
 	LEFT JOIN follows f ON (f.pubkey = e.pubkey)
 	LEFT JOIN bookmarks bm ON (bm.note_id = e.id)
 	WHERE root_event_id IN ($1)
 	AND e.event_id = t.event_id
-	AND e.kind = 1 AND b.pubkey IS NULL AND s.event_id IS NULL AND e.garbage = false;`
+	AND e.kind = 1 AND b.pubkey IS NULL AND e.garbage = false;`
 
 	var treeRows *sql.Rows
 	treeRows, err = st.GormDB.WithContext(ctx).Raw(treeQry, event.Event.ID).Rows()

--- a/internal/http/controllers.go
+++ b/internal/http/controllers.go
@@ -790,7 +790,7 @@ func (c *Controller) GetRelays() http.HandlerFunc {
 
 // GetNewNotesCount godoc
 // @Summary      Get count of new notes
-// @Description  Returns the number of notes newer than the last seen note id
+// @Description  Returns the number of notes newer than the stored read watermark for the given context
 // @Tags         notes
 // @Accept       json
 // @Produce      json
@@ -833,24 +833,7 @@ func (c *Controller) GetNewNotesCount() http.HandlerFunc {
 		response.Message = "new notes count"
 		response.Context = p.Context
 
-		// Count notes newer than the last-seen id, not newer than the cursor.
-		// The cursor is the lower bound of the current page, so every note on
-		// screen already has id > cursor — counting against it overstates the
-		// "new notes" badge by (part of) the current page. The last-seen id
-		// (MAX(note_id) from the seen table) only excludes notes already shown.
-		lastSeenID, err := c.Db.GetLastSeenID(ctx)
-		if err != nil {
-			response.Status = "error"
-			response.Message = err.Error()
-			response.Data = "0"
-
-			if err = json.NewEncoder(w).Encode(&response); err != nil {
-				panic(err)
-			}
-			return
-		}
-
-		count, err := c.Db.GetNewNotesCount(ctx, uint64(lastSeenID), options)
+		count, err := c.Db.GetNewNotesCount(ctx, p.Context, options)
 
 		response.Data = fmt.Sprintf("%d", count)
 
@@ -867,42 +850,80 @@ func (c *Controller) GetNewNotesCount() http.HandlerFunc {
 	}
 }
 
-// GetLastSeenID godoc
-// @Summary      Last seen note id
-// @Description  Last seen note id
+// MarkCaughtUp godoc
+// @Summary      Mark feed as caught up
+// @Description  Stores the current MAX(event_created_at) for the given context as the read watermark. Call this when paginating forward yields no more notes.
 // @Tags         notes
 // @Accept       json
 // @Produce      json
+// @Param        context  query  string  false  "Feed context" Enums(follow,bookmark,global)
 // @Success      200  {object}  Response
-// @Failure      400  {string}  string    "error"
-// @Failure      404  {string}  string    "error"
-// @Failure      500  {string}  string    "error"
-// @Router       /api/getlastseenid [get]
-func (c *Controller) GetLastSeenID() http.HandlerFunc {
+// @Failure      500  {string}  string  "error"
+// @Router       /api/notes/caught-up [post]
+func (c *Controller) MarkCaughtUp() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
 		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 		defer cancel()
 
-		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Access-Control-Allow-Origin", "*") // for CORS
-		w.WriteHeader(http.StatusOK)
+		feedContext := r.URL.Query().Get("context")
+		if feedContext == "" {
+			feedContext = "follow"
+		}
 
-		maxid, err := c.Db.GetLastSeenID(ctx)
+		var options db.Options
+		switch feedContext {
+		case "bookmark":
+			options = db.Options{Follow: false, BookMark: true}
+		case "global":
+			options = db.Options{Follow: false, BookMark: false}
+		default:
+			options = db.Options{Follow: true, BookMark: false}
+		}
 
-		response := &Response{}
-		response.Status = "ok"
-		response.Message = "new notes count"
-		response.Data = maxid
+		response := &Response{Status: "ok", Message: "caught up", Context: feedContext}
+
+		if err := c.Db.SetCaughtUpAt(ctx, feedContext, options); err != nil {
+			response.Status = "error"
+			response.Message = err.Error()
+		}
+
+		render.JSON(w, r, response)
+	}
+}
+
+// GetCaughtUp godoc
+// @Summary      Get read watermark
+// @Description  Returns the event_created_at timestamp that was last stored as the read watermark for the given context.
+// @Tags         notes
+// @Accept       json
+// @Produce      json
+// @Param        context  query  string  false  "Feed context" Enums(follow,bookmark,global)
+// @Success      200  {object}  Response
+// @Failure      500  {string}  string  "error"
+// @Router       /api/notes/caught-up [get]
+func (c *Controller) GetCaughtUp() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+
+		feedContext := r.URL.Query().Get("context")
+		if feedContext == "" {
+			feedContext = "follow"
+		}
+
+		at, err := c.Db.GetCaughtUpAt(ctx, feedContext)
+
+		response := &Response{Status: "ok", Message: "caught up at", Context: feedContext, Data: at}
 
 		if err != nil {
 			response.Status = "error"
 			response.Message = err.Error()
 			response.Data = 0
 		}
-		err = json.NewEncoder(w).Encode(response)
-		if err != nil {
-			panic(err)
-		}
+
+		render.JSON(w, r, response)
 	}
 }
 

--- a/internal/http/routes.go
+++ b/internal/http/routes.go
@@ -45,7 +45,8 @@ func routes(c *Controller, port string, cfg *ServerConfig) *chi.Mux {
 
 	router.Get("/api/getnewnotescount", c.GetNewNotesCount())
 
-	router.Get("/api/getlastseenid", c.GetLastSeenID())
+	router.Get("/api/notes/caught-up", c.GetCaughtUp())
+	router.Post("/api/notes/caught-up", c.MarkCaughtUp())
 
 	/**
 	 * Put a user on the naughty list


### PR DESCRIPTION
## Summary

- Introduces a `watermarks` table (one row per feed context) to track the read position as a Unix timestamp
- `GetNewNotesCount` now counts `WHERE event_created_at > watermark` instead of `WHERE id > MAX(seen.note_id)`
- Falls back to `NOW() - 24h` when no watermark has been set yet for a context
- Removes the `seens` table entirely — including population in `GetInbox` and the JOIN in `FindEvent`

## New endpoints

| Method | Route | Purpose |
|--------|-------|---------|
| `POST` | `/api/notes/caught-up?context=<ctx>` | Set watermark to current `MAX(event_created_at)` for the context |
| `GET`  | `/api/notes/caught-up?context=<ctx>` | Return the current watermark value |

## Test plan

- [ ] Run migration `000007_create_watermarks_table`
- [ ] Call `GET /api/getnewnotescount?context=follow` with no watermark — should return count based on last 24h
- [ ] Call `POST /api/notes/caught-up?context=follow` — should return `ok`
- [ ] Call `GET /api/getnewnotescount?context=follow` again — count should be 0
- [ ] Ingest new notes, poll count again — should reflect only notes newer than the watermark
- [ ] Verify `GET /api/notes/caught-up?context=follow` returns the stored timestamp
- [ ] Verify thread view (`FindEvent`) still shows all replies

Closes #40